### PR TITLE
Add a file converter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ daq_add_library (WIBFragmentDecoder.cpp LINK_LIBRARIES)
 ##############################################################################
 daq_add_python_bindings(*.cpp LINK_LIBRARIES ${PROJECT_NAME} daqdataformats::daqdataformats detdataformats::detdataformats)
 
+daq_add_unit_test(WIBtoWIB2_test LINK_LIBRARIES detdataformats::detdataformats)
+
 ##############################################################################
 # Applications
 # daq_add_application(hdf5_demo_tpc_decoder demo_tpc_decoder.cpp LINK_LIBRARIES ${PROJECT_NAME})

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,12 +96,24 @@ of frames.
 
 ## File conversion
 It's possible to transform binary files using the old `WIBFrame` format to the
-newer `WIB2Frame` format. That means that the ADC values will be preserved, as
-well as other values found in the header such as the crate, slot, fiber number.
-The timestamps will be overwritten to differ by 32 to avoid warnings and other
-issues when these files are being read by readout. In python:
+newer `WIB2Frame` or `WIBEthFrame` format. That means that the ADC values will
+be preserved, as well as other values found in the header such as the crate,
+slot, fiber number. The timestamps will be overwritten to differ by 32 (by 32 *
+64 for `WIBEthFrame`) to avoid warnings and other issues when these files are
+being read by readout. In python:
 
+For WIB -> WIB2
 ```
 from rawdatautils import file_conversion
-file_conversion.convert_file('/path/to/input/file', '/path/to/output/file')
+file_conversion.wib_binary_to_wib2_binary('/path/to/input/file', '/path/to/output/file')
 ```
+and for WIB -> WIBEth
+```
+from rawdatautils import file_conversion
+file_conversion.wib_binary_to_wibeth_binary('/path/to/input/file', '/path/to/output/file')
+```
+
+When transforming WIB -> WIBEth it will create 4 files lblecause `WIBFrames`
+have 256 channels and `WIBEthFrames` have 64, so the first file has the first 64
+channels, the second file has the next 64 channels and so on.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,3 +94,14 @@ number of frames in the fragment it will try to read out of bounds.
 `np_array_timestamp_data` under the hood with the correct checks on the number
 of frames.
 
+## File conversion
+It's possible to transform binary files using the old `WIBFrame` format to the
+newer `WIB2Frame` format. That means that the ADC values will be preserved, as
+well as other values found in the header such as the crate, slot, fiber number.
+The timestamps will be overwritten to differ by 32 to avoid warnings and other
+issues when these files are being read by readout. In python:
+
+```
+from rawdatautils import file_conversion
+file_conversion.convert_file('/path/to/input/file', '/path/to/output/file')
+```

--- a/include/rawdatautils/WIBtoWIB2.hpp
+++ b/include/rawdatautils/WIBtoWIB2.hpp
@@ -1,0 +1,68 @@
+/**
+ * @file WIBtoWIB2.hpp Implementation of functions to convert files from the old WIB format to WIB2
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef RAWDATAUTILS_INCLUDE_WIBTOWIB2_HPP_
+#define RAWDATAUTILS_INCLUDE_WIBTOWIB2_HPP_
+
+#include <cstdint>
+#include <iostream>
+#include <fstream>
+#include <filesystem>
+#include "detdataformats/wib/WIBFrame.hpp"
+#include "detdataformats/wib2/WIB2Frame.hpp"
+
+namespace dunedaq::rawdatautils {
+
+detdataformats::wib2::WIB2Frame
+wibtowib2(detdataformats::wib::WIBFrame* fr, uint64_t timestamp=0) {
+  detdataformats::wib2::WIB2Frame res;
+  for (int i = 0; i < 256; ++i) {
+    res.set_adc(i, fr->get_channel(i));
+  }
+  auto header = fr->get_wib_header();
+  res.header.version = header->version;
+  res.header.crate = header->crate_no;
+  res.header.slot = header->slot_no;
+  res.header.link = header->fiber_no;
+  res.set_timestamp(timestamp);
+  return res;
+}
+
+void
+wibftowib2f(std::string& filename, std::string& output) {
+  std::ifstream file(filename.c_str(), std::ios::binary);
+  std::ofstream out(output.c_str(), std::ios::binary);
+  std::cout << "Transforming " << filename << " to " << output << '\n';
+  auto size = std::filesystem::file_size(filename);
+  std::vector<char> v(size);
+  file.read(v.data(), size);
+  int num_frames = size / sizeof(detdataformats::wib::WIBFrame);
+  std::cout << "Number of frames found: "<< num_frames << '\n';
+  auto ptr = reinterpret_cast<detdataformats::wib::WIBFrame*>(v.data());
+  uint64_t timestamp = ptr->get_timestamp();
+  uint64_t first_timestamp = timestamp;
+  int count = 0;
+  while(num_frames--){
+    auto new_ts = ptr->get_timestamp();
+    if ((new_ts - first_timestamp) != count++ * 25) {
+      std::cout << "Timestamp " << new_ts << "doesn't differ by 25 from the previous timestamp";
+      std::cout << ", it will be overwritten " << '\n';
+    }
+    auto wib2fr = wibtowib2(ptr, timestamp);
+    timestamp += 32;
+    ptr++;
+    out.write(reinterpret_cast<char*>(&wib2fr), sizeof(wib2fr));
+  }
+  file.close();
+  out.close();
+}
+
+
+} // namespace dunedaq::rawdatautils
+
+#endif // RAWDATAUTILS_INCLUDE_WIBTOWIB2_HPP_

--- a/include/rawdatautils/WIBtoWIB2.hpp
+++ b/include/rawdatautils/WIBtoWIB2.hpp
@@ -16,7 +16,8 @@
 #include "detdataformats/wib/WIBFrame.hpp"
 #include "detdataformats/wib2/WIB2Frame.hpp"
 
-namespace dunedaq::rawdatautils {
+namespace dunedaq {
+namespace rawdatautils {
 
 detdataformats::wib2::WIB2Frame
 wibtowib2(detdataformats::wib::WIBFrame* fr, uint64_t timestamp=0) {
@@ -34,13 +35,14 @@ wibtowib2(detdataformats::wib::WIBFrame* fr, uint64_t timestamp=0) {
 }
 
 void
-wibftowib2f(std::string& filename, std::string& output) {
+wib_binary_to_wib2_binary(std::string& filename, std::string& output) {
   std::ifstream file(filename.c_str(), std::ios::binary);
   std::ofstream out(output.c_str(), std::ios::binary);
   std::cout << "Transforming " << filename << " to " << output << '\n';
   auto size = std::filesystem::file_size(filename);
   std::vector<char> v(size);
   file.read(v.data(), size);
+  file.close();
   int num_frames = size / sizeof(detdataformats::wib::WIBFrame);
   std::cout << "Number of frames found: "<< num_frames << '\n';
   auto ptr = reinterpret_cast<detdataformats::wib::WIBFrame*>(v.data());
@@ -50,7 +52,7 @@ wibftowib2f(std::string& filename, std::string& output) {
   while(num_frames--){
     auto new_ts = ptr->get_timestamp();
     if ((new_ts - first_timestamp) != count++ * 25) {
-      std::cout << "Timestamp " << new_ts << "doesn't differ by 25 from the previous timestamp";
+      std::cout << "Timestamp " << new_ts << " doesn't differ by 25 from the previous timestamp";
       std::cout << ", it will be overwritten " << '\n';
     }
     auto wib2fr = wibtowib2(ptr, timestamp);
@@ -58,11 +60,15 @@ wibftowib2f(std::string& filename, std::string& output) {
     ptr++;
     out.write(reinterpret_cast<char*>(&wib2fr), sizeof(wib2fr));
   }
-  file.close();
   out.close();
+}
+
+void
+wib_hdf5_to_wib2_binary(std::string& filename, std::string& output) {
 }
 
 
 } // namespace dunedaq::rawdatautils
+}
 
 #endif // RAWDATAUTILS_INCLUDE_WIBTOWIB2_HPP_

--- a/include/rawdatautils/WIBtoWIBEth.hpp
+++ b/include/rawdatautils/WIBtoWIBEth.hpp
@@ -1,0 +1,81 @@
+/**
+ * @file WIBtoWIBEth.hpp Implementation of functions to convert files from the old WIB format to WIBEth
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef RAWDATAUTILS_INCLUDE_WIBTOWIBETH_HPP_
+#define RAWDATAUTILS_INCLUDE_WIBTOWIBETH_HPP_
+
+#include <cstdint>
+#include <iostream>
+#include <fstream>
+#include <filesystem>
+#include "detdataformats/wib/WIBFrame.hpp"
+#include "detdataformats/wibeth/WIBEthFrame.hpp"
+
+namespace dunedaq {
+namespace rawdatautils {
+
+detdataformats::wibeth::WIBEthFrame
+wibtowibeth(detdataformats::wib::WIBFrame* fr, uint64_t timestamp=0, int starting_channel=0) {
+  detdataformats::wibeth::WIBEthFrame res;
+  for (int j = 0; j < 64; ++j) {
+    for (int i = 0; i < 64; ++i) {
+      res.set_adc(i, j, (fr + j)->get_channel(starting_channel + i));
+    }
+  }
+  auto header = fr->get_wib_header();
+  res.daq_header.version = header->version; //Warning, in WIBFrames version has 5 bits and here it has 4
+  res.daq_header.crate_id = header->crate_no;
+  res.daq_header.slot_id = header->slot_no;
+  res.daq_header.stream_id = header->fiber_no;
+  res.set_timestamp(timestamp);
+  return res;
+}
+
+void
+wib_binary_to_wibeth_binary(std::string& filename, std::string& output) {
+  std::ifstream file(filename.c_str(), std::ios::binary);
+  std::cout << "Transforming " << filename << " to " << output << '\n';
+  auto size = std::filesystem::file_size(filename);
+  std::vector<char> v(size);
+  file.read(v.data(), size);
+  file.close();
+  std::cout << "Number of frames found: "<< size / sizeof(detdataformats::wib::WIBFrame) << '\n';
+  std::vector<int> starting_channel {0, 64, 128, 192};
+  for (auto& sc : starting_channel) {
+    auto ptr = reinterpret_cast<detdataformats::wib::WIBFrame*>(v.data());
+    uint64_t timestamp = ptr->get_timestamp();
+    uint64_t first_timestamp = timestamp;
+    int count = 0;
+    int num_frames = size / sizeof(detdataformats::wib::WIBFrame);
+    std::ofstream out((output + "_" + std::to_string(sc / 64)).c_str(), std::ios::binary);
+    while(num_frames >= 64){
+      auto new_ts = ptr->get_timestamp();
+      if ((new_ts - first_timestamp) != count++ * (25 * 64)) {
+        std::cout << "Timestamp " << new_ts << " doesn't differ by 25 from the previous timestamp";
+        std::cout << ", it will be overwritten " << '\n';
+      }
+      auto wibethfr = wibtowibeth(ptr, timestamp, sc);
+      timestamp += 32 * 64;
+      ptr += 64;
+      num_frames -= 64;
+      out.write(reinterpret_cast<char*>(&wibethfr), sizeof(wibethfr));
+    }
+    out.close();
+  }
+
+}
+
+void
+wib_hdf5_to_wibeth_binary(std::string& filename, std::string& output) {
+}
+
+
+} // namespace dunedaq::rawdatautils
+}
+
+#endif // RAWDATAUTILS_INCLUDE_WIBTOWIBETH_HPP_

--- a/pybindsrc/file_conversion.cpp
+++ b/pybindsrc/file_conversion.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "rawdatautils/WIBtoWIB2.hpp"
+#include "rawdatautils/WIBtoWIBEth.hpp"
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
@@ -23,7 +24,10 @@ namespace python {
 void
 register_file_conversion(py::module& m)
 {
-  m.def("convert_file", &wibftowib2f);
+  m.def("wib_hdf5_to_wib2_binary", &wib_hdf5_to_wib2_binary);
+  m.def("wib_binary_to_wib2_binary", &wib_binary_to_wib2_binary);
+  m.def("wib_hdf5_to_wibeth_binary", &wib_hdf5_to_wibeth_binary);
+  m.def("wib_binary_to_wibeth_binary", &wib_binary_to_wibeth_binary);
 }
 
 } // namespace python

--- a/pybindsrc/file_conversion.cpp
+++ b/pybindsrc/file_conversion.cpp
@@ -1,0 +1,32 @@
+/**
+ * @file file_conversion.cpp Python bindings for file conversions between formats
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "rawdatautils/WIBtoWIB2.hpp"
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+namespace dunedaq {
+namespace rawdatautils {
+
+namespace fc {
+namespace python {
+
+void
+register_file_conversion(py::module& m)
+{
+  m.def("convert_file", &wibftowib2f);
+}
+
+} // namespace python
+} // namespace file_conversion
+} // namespace rawdatautils
+} // namespace dunedaq

--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -21,6 +21,12 @@ extern void register_unpack(py::module &);
 }
 }
 
+namespace fc{
+namespace python {
+extern void register_file_conversion(py::module &);
+}
+}
+
 namespace python {
 
 PYBIND11_MODULE(_daq_rawdatautils_py, m) {
@@ -29,6 +35,9 @@ PYBIND11_MODULE(_daq_rawdatautils_py, m) {
 
     py::module_ unpack_module = m.def_submodule("unpack");
     unpack::python::register_unpack(unpack_module);
+
+    py::module_ fc_module = m.def_submodule("file_conversion");
+    fc::python::register_file_conversion(fc_module);
 
 }
 

--- a/python/rawdatautils/file_conversion/__init__.py
+++ b/python/rawdatautils/file_conversion/__init__.py
@@ -1,0 +1,1 @@
+from .._daq_rawdatautils_py.file_conversion import *

--- a/unittest/WIBtoWIB2_test.cxx
+++ b/unittest/WIBtoWIB2_test.cxx
@@ -1,0 +1,64 @@
+/**
+ * @file WIBtoWIB2_test.cxx Unit Tests for the WIB -> WIB2 file converter
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+/**
+ * @brief Name of this test module
+ */
+#define BOOST_TEST_MODULE WIBtoWIB2_test // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+#include "rawdatautils/WIBtoWIB2.hpp"
+#include "detdataformats/wib/WIBFrame.hpp"
+
+#include <random>
+
+namespace dunedaq{
+namespace rawdatautils{
+
+BOOST_AUTO_TEST_SUITE(WIBtoWIB2_test)
+
+std::mt19937 mt(1000007);
+
+BOOST_AUTO_TEST_CASE(WIBtoWIB2_test1)
+{
+
+  std::uniform_real_distribution<double> dist(0, 4096);
+
+  std::vector<int> adcs;
+  for (int i = 0; i < 256; i++) {
+    int num = dist(mt);
+    adcs.push_back(num);
+  }
+  
+  detdataformats::wib::WIBFrame fr;
+  for (int i = 0; i < 256; i++){
+    fr.set_channel(i, adcs[i]);
+  }
+  auto header = fr.get_wib_header();
+  header->version = 31;
+  header->crate_no = 31;
+  header->slot_no = 7;
+  header->fiber_no = 7;
+  fr.set_timestamp(1844674407370955161U); //2**48-1
+
+  auto wib2fr = wibtowib2(&fr, 1844674407370955161U);
+  for (int i = 0; i < 256; i++){
+    BOOST_REQUIRE_EQUAL(adcs[i], wib2fr.get_adc(i));
+  }
+  BOOST_REQUIRE_EQUAL(wib2fr.header.version, 31);
+  BOOST_REQUIRE_EQUAL(wib2fr.header.crate, 31);
+  BOOST_REQUIRE_EQUAL(wib2fr.header.slot, 7);
+  BOOST_REQUIRE_EQUAL(wib2fr.header.link, 7);
+  BOOST_REQUIRE_EQUAL(wib2fr.get_timestamp(), 1844674407370955161U);
+}
+
+} // namespace dunedaq
+} // namespace rawdatautils
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds utilities for converting old binary files of data with `WIBFrame`s to the `WIB2Frame` format. ADCs are kept the same, but timestamps are overwritten so that the difference is 32 in the new file to avoid issues and errors when reading them from readout, for example. In addition, the fields that could be translated in the header have been translated to the `WIB2Frame` format. The following fields of the header of the `WIBFrame` are not in the new `WIB2Frame`s since I didn't see a direct equivalent:
`sof¸ reserved_1, mm, oos, reserved_2, wib_errors, wib_counter_1, z`
Besides the unit test, I tested that the ADC values remain the same. I also ran with a transformed file as a `frames.bin` file and the DQM display plots look fine


![2022-11-28-180118_2288x1274_scrot](https://user-images.githubusercontent.com/22276694/204339375-60032b4c-0c4f-4811-a7fd-5cec942d5c1b.png)

The instructions are now in the README for running the converter (using python bindings, but runs in C++ for speed, it takes ~4 seconds for a 1 GB file, including reading the input file and writing the output file)