### PR TITLE
added a script to print out specific file-level attributes from an HDF5 raw data file

### DIFF
--- a/scripts/print_attributes_for_json_metadata.py
+++ b/scripts/print_attributes_for_json_metadata.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+from hdf5libs import HDF5RawDataFile
+
+import click
+import json
+from datetime import datetime
+
+@click.command()
+@click.argument('filename', type=click.Path(exists=True))
+
+def main(filename):
+
+    h5_file = HDF5RawDataFile(filename)
+
+    attr_name_list = ["operational_environment", "creation_timestamp", "closing_timestamp"]
+
+    attr_dict = {}
+    for attr_name in attr_name_list:
+        value = h5_file.get_attribute(attr_name)
+        if "timestamp" in attr_name:
+            attr_dict[attr_name] = datetime.fromtimestamp(float(value)/1000.0).isoformat()
+        else:
+            attr_dict[attr_name] = value
+
+    attr_json = json.dumps(attr_dict)
+    print(attr_json)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script will be useful as part of changes that we want to make in the creation of the JSON metadata files that we send to offline.

This PR depends on the one in hdf5libs that adds the get_attribute method to the python bindings. [here](https://github.com/DUNE-DAQ/hdf5libs/pull/53) 