### PR TITLE
ProtoDUNE CRT integration

### DIFF
--- a/pybindsrc/CRTUnpacker.cpp
+++ b/pybindsrc/CRTUnpacker.cpp
@@ -1,0 +1,145 @@
+/**
+ * @file CRTUnpacker.cc Fast C++ -> numpy CRT (fixed size) format unpacker
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "fddetdataformats/CRTFixedSizeFrame.hpp"
+#include "daqdataformats/Fragment.hpp"
+
+#include <cstdint>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+namespace dunedaq::rawdatautils::crt {
+
+/**                                                                                                                                                                                                                
+ * @brief Gets number of CRTFixedSizeFrames in a fragment                                                                                                                                                                
+ */
+uint32_t get_n_frames(daqdataformats::Fragment const& frag){
+  return (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::CRTFixedSizeFrame);
+}
+
+
+/**                                                                                                                                                                         \
+                                                                                                                                                                             
+ * @brief Unpacks module numbers for CRTFixedSizeFrames into a numpy array with dimensions                                                                                        
+ * (nframes)                                                                                                                                                                \
+                                                                                                                                                                             
+ */
+py::array_t<uint16_t> np_array_modules_data(void* data, int nframes){
+
+  py::array_t<uint16_t> modules(nframes);
+  auto ptr = static_cast<uint16_t*>(modules.request().ptr);
+
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::CRTFixedSizeFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::CRTFixedSizeFrame));
+    ptr[i] = fr->get_module();
+  }
+
+  return modules;
+}
+
+/**                                                                                                                                                                         \
+                                                                                                                                                                             
+ * @brief Unpacks module numbers for Fragment that contains CRTFixedSizeFrames into a numpy array with dimensions                                                                \
+                                                                                                                                                                             
+ */
+py::array_t<uint16_t> np_array_modules(daqdataformats::Fragment& frag){
+  return np_array_modules_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::CRTFixedSizeFrame));
+}
+
+
+/**
+ * @brief Unpacks data containing CRTFixedSizeFrames into a numpy array with the ADC
+ * values and dimension (number of CRTFixedSizeFrames, adcs_per_module (=64))
+ * Warning: It doesn't check that nframes is a sensible value (can read out of bounds)
+ */
+py::array_t<int16_t> np_array_adc_data(void* data, int nframes){
+  
+  const auto adcs_per_module     = fddetdataformats::CRTFixedSizeFrame::s_num_adcs;
+
+  py::array_t<int16_t> ret(nframes * adcs_per_module);
+  auto ptr = static_cast<int16_t*>(ret.request().ptr);
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::CRTFixedSizeFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::CRTFixedSizeFrame));
+    for (size_t j=0; j<adcs_per_module; ++j) {
+      ptr[i*adcs_per_module + j] = fr->get_adc(j);
+    }
+  }
+  ret.resize({nframes, adcs_per_module});
+
+  return ret;
+}
+
+/**
+ * @brief Unpacks data containing CRTFixedSizeFrames into a numpy array with the channel
+ * values and dimension (number of CRTFixedSizeFrames, adcs_per_module (=64))
+ * Warning: It doesn't check that nframes is a sensible value (can read out of bounds)
+ */
+py::array_t<uint8_t> np_array_channel_data(void* data, int nframes){
+  
+  const auto adcs_per_module     = fddetdataformats::CRTFixedSizeFrame::s_num_adcs;
+
+  py::array_t<uint8_t> ret(nframes * adcs_per_module);
+  auto ptr = static_cast<uint8_t*>(ret.request().ptr);
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::CRTFixedSizeFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::CRTFixedSizeFrame));
+    for (size_t j=0; j<adcs_per_module; ++j) {
+      ptr[i*adcs_per_module + j] = fr->get_channel(j);
+    }
+  }
+  ret.resize({nframes, adcs_per_module});
+
+  return ret;
+}
+
+/**
+ * @brief Unpacks data containing CRTFixedSizeFrames into a numpy array with the
+ * timestamps with dimension (number of CRTFixedSizeFrames)
+ * Warning: It doesn't check that nframes is a sensible value (can read out of bounds)
+ */
+
+py::array_t<uint64_t> np_array_timestamp_data(void* data, int nframes){
+
+  //const auto adcs_per_module     = fddetdataformats::CRTFixedSizeFrame::s_num_adcs;
+
+  py::array_t<uint64_t> ret(nframes);
+  auto ptr = static_cast<uint64_t*>(ret.request().ptr);
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::CRTFixedSizeFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::CRTFixedSizeFrame));
+    ptr[i] = fr->get_timestamp();
+  }
+  
+  return ret;
+}
+
+
+/**
+ * @brief Unpacks a Fragment containing CRTFixedSizeFrames into a numpy array with the
+ * ADC values and dimension (number of CRTFixedSizeFrames in the Fragment, 64)
+ */
+py::array_t<int16_t> np_array_adc(daqdataformats::Fragment& frag){
+  return np_array_adc_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::CRTFixedSizeFrame));
+}
+
+/**
+ * @brief Unpacks a Fragment containing CRTFixedSizeFrames into a numpy array with the
+ * channel values and dimension (number of CRTFixedSizeFrames in the Fragment, 64)
+ */
+py::array_t<uint8_t> np_array_channel(daqdataformats::Fragment& frag){
+  return np_array_channel_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::CRTFixedSizeFrame));
+}
+
+
+/**
+ * @brief Unpacks the timestamps in a Fragment containing WIBFrames into a numpy
+ * array with dimension (number of CRTFixedSizeFrames in the Fragment)
+ */
+py::array_t<uint64_t> np_array_timestamp(daqdataformats::Fragment& frag){
+  return np_array_timestamp_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::CRTFixedSizeFrame));
+}
+
+} // namespace dunedaq::rawdatautils::crt // NOLINT

--- a/pybindsrc/unpack.cpp
+++ b/pybindsrc/unpack.cpp
@@ -11,6 +11,7 @@
 #include "fddetdataformats/DAPHNEFrame.hpp"
 #include "fddetdataformats/WIBEthFrame.hpp"
 #include "fddetdataformats/TDE16Frame.hpp"
+#include "fddetdataformats/CRTFixedSizeFrame.hpp"
 #include "daqdataformats/Fragment.hpp"
 
 #include <pybind11/numpy.h>
@@ -88,6 +89,18 @@ namespace tde {
 
 }
 
+namespace crt {
+  extern uint32_t get_n_frames(daqdataformats::Fragment const& frag);
+  extern py::array_t<int16_t> np_array_adc(daqdataformats::Fragment& frag);
+  extern py::array_t<int16_t> np_array_adc_data(void* data, int nframes);
+  extern py::array_t<uint8_t> np_array_channel(daqdataformats::Fragment& frag);
+  extern py::array_t<uint8_t> np_array_channel_data(void* data, int nframes);
+  extern py::array_t<uint64_t> np_array_timestamp(daqdataformats::Fragment& frag);
+  extern py::array_t<uint64_t> np_array_timestamp_data(void* data, int nframes);
+  extern py::array_t<uint16_t> np_array_modules(daqdataformats::Fragment& frag);
+  extern py::array_t<uint16_t> np_array_modules_data(void* data, int nframes);
+}
+
 namespace unpack {
 namespace python {
 
@@ -137,7 +150,17 @@ register_unpack(py::module& m) {
   tde_module.def("get_n_frames", &tde::get_n_frames);
   tde_module.def("np_array_timestamp_data", &tde::np_array_timestamp_data);
   tde_module.def("np_array_channel_data", &tde::np_array_channel_data);
-  
+
+  py::module_ crt_module = m.def_submodule("crt");
+  crt_module.def("get_n_frames", &crt::get_n_frames);
+  crt_module.def("np_array_modules", &crt::np_array_modules);
+  crt_module.def("np_array_adc", &crt::np_array_adc);
+  crt_module.def("np_array_channel", &crt::np_array_channel);
+  crt_module.def("np_array_timestamp", &crt::np_array_timestamp);
+  crt_module.def("np_array_modules_data", &crt::np_array_modules_data);
+  crt_module.def("np_array_adc_data", &crt::np_array_adc_data);
+  crt_module.def("np_array_timestamp_data", &crt::np_array_timestamp_data);  
+  crt_module.def("np_array_channel_data", &crt::np_array_channel_data);
 }
 
 } // namespace python

--- a/pybindsrc/unpack.cpp
+++ b/pybindsrc/unpack.cpp
@@ -11,7 +11,7 @@
 #include "fddetdataformats/DAPHNEFrame.hpp"
 #include "fddetdataformats/WIBEthFrame.hpp"
 #include "fddetdataformats/TDE16Frame.hpp"
-#include "fddetdataformats/CRTFixedSizeFrame.hpp"
+#include "fddetdataformats/CRTFrame.hpp"
 #include "daqdataformats/Fragment.hpp"
 
 #include <pybind11/numpy.h>

--- a/python/rawdatautils/unpack/crt/__init__.py
+++ b/python/rawdatautils/unpack/crt/__init__.py
@@ -1,0 +1,1 @@
+from ..._daq_rawdatautils_py.unpack.crt import *

--- a/python/rawdatautils/unpack/utils.py
+++ b/python/rawdatautils/unpack/utils.py
@@ -12,6 +12,7 @@ import detchannelmaps
 from rawdatautils.unpack.dataclasses import *
 import rawdatautils.unpack.wibeth
 import rawdatautils.unpack.daphne
+import rawdatautils.unpack.crt
 import h5py
 
 #analysis imports

--- a/scripts/crt_decoder.py
+++ b/scripts/crt_decoder.py
@@ -138,17 +138,17 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary):
             for fr_num in range(n_frames):
                 scanned_channels += 1
                 main_line = f"{det_crate:^10} {det_slot:^10} {det_link:^10} {modules[fr_num]:^10} "
-                ch_lines = []
-                adc_lines = []
+                ch_line = ""
+                adc_line = ""
                 if adc_stats:
                     for ch in channels[fr_num]:
-                        if(adcs[fr_num][channels[fr_num].tolist().index(ch)] != 0):
-                            ch_lines.append(f"{ch:^5} ")
+                        if(ch != 0):
+                            ch_line += f"{ch:^5}"
                         if(ch>63):
                             print("Error, channel out of expected range!")
                     for adc_val in adcs[fr_num]:
                         if(adc_val != 0):
-                            adc_lines.append(f"{adc_val:^5} ")
+                            adc_line += f"{adc_val:^5}"
                     if fragType == FragmentType.kCRT.value:
                         if np.std(adcs[:]) > 10:
                             active_channels += 1
@@ -168,8 +168,8 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary):
                     main_line += ts_status
 
                 print(main_line)
-                print(ch_lines)
-                print(adc_lines)
+                print(ch_line)
+                print(adc_line)
 
             #if tslot == geo_info.det_slot:
             #    continue

--- a/scripts/crt_decoder.py
+++ b/scripts/crt_decoder.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Created on: 17/05/2023 
+
+Author: Vitaliy Popov
+
+Description: Script checks CRT data and prints some of the ADC stats.
+
+"""
+
+
+from hdf5libs import HDF5RawDataFile
+
+import daqdataformats
+import detdataformats
+from daqdataformats import FragmentType
+from rawdatautils.unpack.crt import *
+import detchannelmaps
+
+import click
+import time
+import numpy as np
+import time
+#import matplotlib.pyplot as plt
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+@click.command()
+@click.argument('filename', type=click.Path(exists=True))
+@click.option('--det', default='HD_CRT', help='Subdetector string (default: HD_CRT)')
+@click.option('--nrecords', '-n', default=-1, help='How many Trigger Records to process (default: all)')
+@click.option('--nskip', default=0, help='How many Trigger Records to skip (default: 0)')
+@click.option('--summary', is_flag=True, help="Print checks summary")
+@click.option('--check_ts', is_flag=True, help="Print timestamps check")
+@click.option('--adc_stats', is_flag=True, help="Print adc stats")
+
+def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary):
+
+    h5_file   = HDF5RawDataFile(filename)
+    records   = h5_file.get_all_record_ids()
+
+    if nskip > len(records):
+        print(f'Requested records to skip {nskip} is greater than number of records {len(records)}. Exiting...')
+        return
+    
+    if nrecords > 0:
+        if (nskip+nrecords) > len(records):
+            nrecords = -1
+        else:
+            nrecords=nskip+nrecords
+            
+    records_to_process = []
+
+    if nrecords==-1:
+        records_to_process = records[nskip:]
+    else:
+        records_to_process = records[nskip:nrecords]
+
+    print(f'Will process {len(records_to_process)} of {len(records)} records.')
+    
+    for r in records_to_process:
+
+        crt_geo_ids    = list(h5_file.get_geo_ids_for_subdetector(r,detdataformats.DetID.string_to_subdetector(det)))
+        
+        if len(crt_geo_ids) == 0:
+            print(f"Record {r} has no data for {det}. Exiting..")
+            return
+        
+        trigger_stamps = []
+        stamp_begin    = []
+        timelines      = []
+
+        active_channels = 0
+        n_channels      = 0
+
+
+        headline = f"{'CRATE':^10} {'SLOT':^10} {'LINK':^10} {'MODULE':^10} "
+        
+        if adc_stats:
+            headline += f" {'MEAN':^10} {'Std.dev.':^10}"
+        
+        if check_ts:
+            headline += f" {'TS stats':^17} {'TS Check':^18}"
+
+        print("-"*114)
+        print(f"{'RECORD':>50}: {r[0]:<15} {time.ctime(h5_file.get_frag(r,crt_geo_ids[0]).get_trigger_timestamp()*16 /1e9):^20}")
+        print("-"*114)
+        print(headline)
+        print("-"*114)
+
+        scanned_channels = 0
+        tslot = -1
+
+        for gid in crt_geo_ids:
+            
+            frag     = h5_file.get_frag(r,gid)
+            det_link = 0xffff & (gid >> 48)
+            det_slot = 0xffff & (gid >> 32)
+            det_crate = 0xffff & (gid >> 16)
+            det_id = 0xffff & gid
+            subdet = detdataformats.DetID.Subdetector(det_id)
+            det_name = detdataformats.DetID.subdetector_to_string(subdet)
+
+            fragType = frag.get_header().fragment_type
+            #print(fragType)
+           
+            if fragType == FragmentType.kCRT.value:
+            
+                timestamps = np_array_timestamp(frag)
+                modules    = np_array_modules(frag)
+                channels   = np_array_channel(frag)
+                adcs       = np_array_adc(frag)
+                n_frames = len(modules)
+                crt_hits = []
+                print(n_frames)
+                for frame in range(n_frames):
+                    hit = {"timestamp":timestamps[frame],"module":modules[frame]}
+
+
+            trigger_stamps.append(frag.get_trigger_timestamp())     
+
+            ts_status = f"{bcolors.FAIL}{'Problems':^20}{bcolors.ENDC}"
+
+            if n_frames == 0:
+                main_line = f"{det_crate:^10} {det_slot:^10} {det_link:^10} {'Empty fragment':^40} "
+                print(main_line)
+
+            for fr_num in range(n_frames):
+                scanned_channels += 1
+                main_line = f"{det_crate:^10} {det_slot:^10} {det_link:^10} {modules[fr_num]:^10} "
+                ch_lines = []
+                adc_lines = []
+                if adc_stats:
+                    for ch in channels[fr_num]:
+                        if(adcs[fr_num][channels[fr_num].tolist().index(ch)] != 0):
+                            ch_lines.append(f"{ch:^5} ")
+                        if(ch>63):
+                            print("Error, channel out of expected range!")
+                    for adc_val in adcs[fr_num]:
+                        if(adc_val != 0):
+                            adc_lines.append(f"{adc_val:^5} ")
+                    if fragType == FragmentType.kCRT.value:
+                        if np.std(adcs[:]) > 10:
+                            active_channels += 1
+                        main_line += f"{np.mean(adcs[fr_num][:]):^10.2f}  {np.std(adcs[fr_num][:]):^10.2f} "
+                    else:
+                        if np.std(adcs[:, fr_num]) > 10:
+                            active_channels += 1
+                        main_line += f"{np.mean(adcs[:, fr_num]):^10.2f}  {np.std(adcs[:, fr_num]):^10.2f} "
+
+                if check_ts:
+                    delta = np.diff(timestamps)
+                    main_line += f"{np.mean(delta):>8.1f}/{np.std(delta):<8.1f}"
+
+                    if np.std(delta) < 2:
+                        ts_status = f"{bcolors.OKGREEN}{'OK':^18}{bcolors.ENDC}"
+
+                    main_line += ts_status
+
+                print(main_line)
+                print(ch_lines)
+                print(adc_lines)
+
+            #if tslot == geo_info.det_slot:
+            #    continue
+            #else:
+            #    tslot = geo_info.det_slot
+            #    print("")
+
+
+        print(f"Number of active/total channels \t-- {active_channels:>20}/{scanned_channels}\n")
+
+        
+
+    if summary:
+
+        print("-"*80)
+        print(f"{'SUMMARY':^80}")
+        print("-"*80)
+        print(f"Processed records \t - \t {len(records_to_process)} \n")
+        print("-"*60)
+        print(f"\t crates \t slots \t\t links")
+        print("-"*60)
+        s = " "
+        if (np.all(timelines) == 1):
+            print(f"Timelines \t - \t {bcolors.OKGREEN} OK {bcolors.ENDC} \n")
+        else:
+            print(f"Timelines \t - \t {bcolors.FAIL} PROBLEMS {bcolors.ENDC} \n")
+
+    print(f"{'Processing finished': ^80}")
+
+if __name__ == '__main__':
+    main()
+
+
+
+
+


### PR DESCRIPTION
Adding an unpacker and decoder to interpret CRT data, based on existing examples, as part of wider CRT integration effort.

Associated pull requests are made for the `mmatt15/crt` branches in [fddetdataformats](https://github.com/DUNE-DAQ/fddetdataformats/pull/16), [daqdataformats](https://github.com/DUNE-DAQ/daqdataformats/pull/52), [fdreadoutlibs](https://github.com/DUNE-DAQ/fdreadoutlibs/pull/162), [fdreadoutmodules](https://github.com/DUNE-DAQ/fdreadoutmodules/pull/14), and [fddaqconf](https://github.com/DUNE-DAQ/fddaqconf/pull/24).

This PR is part of the work associated with [daq-deliverables Issue 125](https://github.com/DUNE-DAQ/daq-deliverables/issues/125).