### PR TITLE
Adding scripts that are used in creating file-transfer metadata files

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -27,10 +27,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: "ghcr.io/dune-daq/sl7-slim-externals:spack-dev-v1.1"
-            os_name: "c7"
-          - image: "ghcr.io/dune-daq/c8-slim-externals:spack-dev-v1.1"
-            os_name: "c8"
+          - image: "ghcr.io/dune-daq/alma9-slim-externals:spack-dev-v2.0"
+            os_name: "a9"
     container:
       image: ${{ matrix.image }}
     defaults:
@@ -51,10 +49,10 @@ jobs:
       run: |
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-          setup_dbt latest|| true
-          release_name="last_fddaq_c8"
+          setup_dbt latest || true
+          release_name="last_fddaq"
           nd_config=$GITHUB_WORKSPACE/daq-release/configs/nddaq/nddaq-develop/release.yaml
-          if grep -q "name: ${REPO}\n" $nd_config; then release_name="last_nddaq_c8"; fi
+          if grep -q "name: ${REPO}\n" $nd_config; then release_name="last_nddaq"; fi
           dbt-create -n $release_name dev-${{ matrix.os_name }}
 
     - name: checkout package for CI

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -50,12 +50,9 @@ jobs:
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest || true
-          release_name=
+          release_name="last_fddaq"
 
-          if [[ -n $( sed -r -n '/- name: '$REPO'$/p' daq-release/configs/fddaq/fddaq-develop/release.yaml ) ]] ; then release_name="last_fddaq"; fi
           if [[ -n $( sed -r -n '/- name: '$REPO'$/p' daq-release/configs/nddaq/nddaq-develop/release.yaml ) ]] ; then release_name="last_nddaq"; fi
-
-          test -z $release_name && exit 10
 
           dbt-create -n $release_name dev-${{ matrix.os_name }}
 
@@ -71,7 +68,7 @@ jobs:
           source env.sh || true
           spack unload $REPO || true
           cp -pr $GITHUB_WORKSPACE/DUNE-DAQ/$REPO $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}/sourcecode
-          dbt-build --unittest # --lint
+          dbt-build # --unittest # --lint
 
     - name: upload build log file
       uses: actions/upload-artifact@v3
@@ -85,8 +82,8 @@ jobs:
     #     name: linting_log_${{ matrix.os_name }}
     #     path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*
 
-    - name: upload unittest output file
-      uses: actions/upload-artifact@v3
-      with:
-        name: unit_tests_log_${{ matrix.os_name }}
-        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/unit_tests*
+    # - name: upload unittest output file
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: unit_tests_log_${{ matrix.os_name }}
+    #     path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/unit_tests*

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -52,9 +52,9 @@ jobs:
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest|| true
-          release_name="last_fddaq"
-          #nd_config=$GITHUB_WORKSPACE/daq-release/configs/nddaq/nddaq-develop/release.yaml
-          #if grep -q "name: ${REPO}\n" $nd_config; then release_name="last_nddaq"; fi
+          release_name="last_fddaq_c8"
+          nd_config=$GITHUB_WORKSPACE/daq-release/configs/nddaq/nddaq-develop/release.yaml
+          if grep -q "name: ${REPO}\n" $nd_config; then release_name="last_nddaq_c8"; fi
           dbt-create -n $release_name dev-${{ matrix.os_name }}
 
     - name: checkout package for CI

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -20,14 +20,14 @@ on:
 
 
 jobs:
-  Spack_Build_against_dev_release:
-    name: spack_build_against_dev_on_${{ matrix.os_name }}
+  Build_against_dev_release:
+    name: build_against_dev_on_${{ matrix.os_name }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - image: "ghcr.io/dune-daq/alma9-slim-externals:spack-dev-v2.0"
+          - image: "ghcr.io/dune-daq/nightly-release-alma9:latest"
             os_name: "a9"
     container:
       image: ${{ matrix.image }}
@@ -50,9 +50,13 @@ jobs:
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest || true
-          release_name="last_fddaq"
-          nd_config=$GITHUB_WORKSPACE/daq-release/configs/nddaq/nddaq-develop/release.yaml
-          if grep -q "name: ${REPO}\n" $nd_config; then release_name="last_nddaq"; fi
+          release_name=
+
+          if [[ -n $( sed -r -n '/- name: '$REPO'$/p' daq-release/configs/fddaq/fddaq-develop/release.yaml ) ]] ; then release_name="last_fddaq"; fi
+          if [[ -n $( sed -r -n '/- name: '$REPO'$/p' daq-release/configs/nddaq/nddaq-develop/release.yaml ) ]] ; then release_name="last_nddaq"; fi
+
+          test -z $release_name && exit 10
+
           dbt-create -n $release_name dev-${{ matrix.os_name }}
 
     - name: checkout package for CI
@@ -61,32 +65,28 @@ jobs:
         path: ${{ github.repository }}
     
     - name: setup build env, build the repo against the development release
-      #- name: setup build env, build and lint the repo against the development release
       run: |
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           cd $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}
           source env.sh || true
           spack unload $REPO || true
           cp -pr $GITHUB_WORKSPACE/DUNE-DAQ/$REPO $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}/sourcecode
-          dbt-build
-          #[[ $REPO == "daq-cmake" ]] && dbt-build || dbt-build --lint
-          dbt-workarea-env
-          #dbt-build --unittest
+          dbt-build --unittest # --lint
 
     - name: upload build log file
       uses: actions/upload-artifact@v3
       with:
-        name: spack_build_log_${{ matrix.os_name }}
+        name: build_log_${{ matrix.os_name }}
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
 
-          #- name: upload linter output file
-          #uses: actions/upload-artifact@v3
-          #with:
-          #name: spack_linting_log_${{ matrix.os_name }}
-          #path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*
+    # - name: upload linter output file
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: linting_log_${{ matrix.os_name }}
+    #     path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*
 
-          #- name: upload unittest output file
-          #uses: actions/upload-artifact@v2
-          #with:
-          #name: spack_unit_tests_log_${{ matrix.os_name }}
-          #path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/unit_tests*
+    - name: upload unittest output file
+      uses: actions/upload-artifact@v3
+      with:
+        name: unit_tests_log_${{ matrix.os_name }}
+        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/unit_tests*

--- a/scripts/createMetadataFilesForDataN.sh
+++ b/scripts/createMetadataFilesForDataN.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+
+# Kurt Biery, October 2021 - November 2023
+
+# decode arguments
+if [ "$1" == "--help" ] || [ "$1" == "-h" ] || [ "$1" == "-?" ]; then
+  echo "Usage: $0 [data_disk_number]"
+  echo "Where data_disk_number defaults to zero."
+  echo "Example: \"$0 3\" looks for new HDF5 files on /data3"
+  exit 1
+fi
+
+data_disk_number=0
+if [ $# -gt 0 ]; then
+  data_disk_number=$1
+fi
+
+# assign parameter values
+dataDirs="/data${data_disk_number} /data${data_disk_number}/transfer_test /data${data_disk_number}/kurtMetadataTests"  # may be a space-separate list
+minDataFileAgeMinutes=0
+maxDataFileAgeMinutes=14400
+filenamePrefixList=( "np04hd_raw" "np04hd_tp" "np02vd_raw" "np02vd_tp" "np04hdcoldbox_raw" "np04hdcoldbox_tp" "np02vdcoldbox_raw" "np02vdcoldbox_tp" )
+
+lockFileDir="/tmp"
+lockFileName=".mdFileCronjob_data${data_disk_number}.lock"
+staleLockFileTimeoutMinutes=30
+
+setupScriptPath="/nfs/home/np04daq/.cron/setupDuneDAQ"
+ourHDF5DumpScript="print_trnumbers_for_json_metadata.py"
+scratchFile="/tmp/metadata_scratch_$$.out"
+requestedJSONFileOutputDir="."  # an empty or "." value puts JSON files in the same dirs as the ROOT files
+logPath="/log/metadataFileCreator/createMDFile_data${data_disk_number}.log"
+extraFieldCommand="python /nfs/home/np04daq/.cron/insert_extra_fields.py"
+let debugLevel=2  # only zero, one, and two are useful, at the moment; two is for performance tracing
+versionOfThisScript="v2.7.4"
+
+# define a function to log messages
+function logMessage() {
+    local msgText=$1
+    local pid=$$
+    local timestamp=`date '+%Y-%m-%d %H:%M:%S'`
+    if [[ "$logPath" != "" ]]; then
+        echo "${timestamp} (${pid}) ${msgText}" >> $logPath
+    else
+        echo "${timestamp} (${pid}) ${msgText}"
+    fi
+}
+
+# initialization
+logMessage "Starting $0 ${versionOfThisScript} for ${dataDirs}."
+cd $lockFileDir
+
+# check if there is an instance of this script already running,
+# as evidenced by the presence of a lock file.  To prevent a stale
+# lock file from causing problems, we only look for lock files that
+# are relatively newer than the "stale lock file timeout".
+existingLockFile=`find ${lockFileDir} -name ${lockFileName} -mmin -${staleLockFileTimeoutMinutes} -print 2>/dev/null`
+if [[ "${existingLockFile}" != "" ]]; then
+    logMessage "Found lock file (${lockFileDir}/${lockFileName}); exiting early to prevent duplicate jobs."
+    exit 1
+fi
+existingLockFile=`ls -alF ${lockFileDir}/${lockFileName} 2>/dev/null`
+if [[ "${existingLockFile}" != "" ]]; then
+    logMessage "Ignoring stale lock file (${existingLockFile})."
+fi
+touch ${lockFileDir}/${lockFileName}
+
+dunedaqSetupAttempted="no"
+processed_one_or_more_files="yes"
+while [[ "${processed_one_or_more_files}" != "" ]]; do
+    processed_one_or_more_files=""
+
+    # 29-Oct-2021, KAB: added loop over filename prefixes
+    for filenamePrefix in ${filenamePrefixList[@]}; do
+
+	dataFileNamePattern="${filenamePrefix}_run??????_*.hdf5"
+	if [[ "$filenamePrefix" == "np02_bde_coldbox" ]] || [[ "$filenamePrefix" == "vd_coldbox_bottom" ]]; then
+            offlineRunTypeReallyOpEnv="vd-coldbox-bottom"
+	elif [[ "$filenamePrefix" == "np04_hd" ]] || [[ "$filenamePrefix" == "np04hd_raw" ]] || [[ "$filenamePrefix" == "np04hd_tp" ]]; then
+            offlineRunTypeReallyOpEnv="hd-protodune"
+	elif [[ "$filenamePrefix" == "np02_vd" ]] || [[ "$filenamePrefix" == "np02vd_raw" ]] || [[ "$filenamePrefix" == "np02vd_tp" ]]; then
+            offlineRunTypeReallyOpEnv="vd-protodune"
+	elif [[ "$filenamePrefix" == "np04_coldbox" ]] || [[ "$filenamePrefix" == "np04hdcoldbox_raw" ]] || [[ "$filenamePrefix" == "np04hdcoldbox_tp" ]]; then
+            offlineRunTypeReallyOpEnv="hd-coldbox"
+	elif [[ "$filenamePrefix" == "np02vdcoldbox_raw" ]] || [[ "$filenamePrefix" == "np02vdcoldbox_tp" ]]; then
+            offlineRunTypeReallyOpEnv="vd-coldbox"
+	elif [[ "$filenamePrefix" == "np02_pds" ]]; then
+            offlineRunTypeReallyOpEnv="vd-protodune-pds"
+	else
+            offlineRunTypeReallyOpEnv=${filenamePrefix}
+	fi
+
+	if [[ $debugLevel -ge 1 ]]; then
+            logMessage "Searching for filenames like \"${dataFileNamePattern}\" in \"${dataDirs}\"."
+            logMessage "Offline run_type is \"${offlineRunTypeReallyOpEnv}\"."
+	fi
+
+	# loop over all of the files that are found in the requested data directories
+	let processed_file_count=0
+	for volatileFileName in $(find ${dataDirs} -maxdepth 1 -name "${dataFileNamePattern}" -type f -mmin +${minDataFileAgeMinutes} -mmin -${maxDataFileAgeMinutes} -print 2>/dev/null | sort -r); do
+
+	    # we assume that we need a periodic touch of the lock file
+	    touch ${lockFileDir}/${lockFileName}
+
+	    # determine the base filename for the current raw data file
+	    baseFileName=`basename $volatileFileName`
+	    fullFileName=${volatileFileName}
+
+	    # determine the JSON file output dir, if not explicitly specified
+	    jsonFileOutputDir=${requestedJSONFileOutputDir}
+	    if [[ "$requestedJSONFileOutputDir" == "" ]] || [[ "$requestedJSONFileOutputDir" == "." ]]; then
+		jsonFileOutputDir=`dirname $volatileFileName`
+	    fi
+
+	    # only do the work if the metadata file doesn't already exist
+	    jsonFileName="${jsonFileOutputDir}/${baseFileName}.json"
+	    if [[ ! -e "${jsonFileName}" ]] && [[ ! -e "${jsonFileName}.copied" ]]; then
+		workingJSONFileName="${jsonFileName}.tmp"
+
+		# if needed, setup dunedaq, etc. so that we can look inside the file
+		if [[ "${dunedaqSetupAttempted}" == "no" ]]; then
+		    if [[ $debugLevel -ge 1 ]]; then logMessage "Setting up dunedaq"; fi
+		    currentDir=`pwd`
+		    tmpDir=`dirname ${setupScriptPath}`
+		    cd $tmpDir
+		    source `basename ${setupScriptPath}` >/dev/null
+		    cd $currentDir
+		    hdf5DumpFullPath=`eval which ${ourHDF5DumpScript} 2>/dev/null`
+		    if [[ "$hdf5DumpFullPath" == "" ]]; then
+			logMessage "ERROR: The ${ourHDF5DumpScript} script was not found!"
+			rm -f ${lockFileDir}/${lockFileName}
+			exit 3
+		    fi
+		    dunedaqSetupAttempted="yes"
+		fi
+
+		# pull the run number out of the filename
+		runNumber=`echo ${baseFileName} | sed 's/\(.*_run\)\([[:digit:]]\+\)\(_.*\)/\2/'`
+		# strip off leading zeroes
+		runNumber=`echo ${runNumber} | sed 's/^0*//'`
+		# convert it to a number (may be needed later if we do range comparisons)
+		let runNumber=$runNumber+0
+
+		# if we don't have a copy of the our HDF5 dumper utility, do what we can...
+		if [[ "$hdf5DumpFullPath" == "" ]]; then
+		    logMessage "Creating ${jsonFileName} without using any extra tools."
+
+		    echo "{" > ${workingJSONFileName}
+		    echo "  \"data_stream\": \"test\"," >> ${workingJSONFileName}
+		    if [[ "`echo ${filenamePrefix} | grep '_tp$'`" != "" ]]; then
+			echo "  \"data_tier\": \"trigprim\"," >> ${workingJSONFileName}
+		    else
+			echo "  \"data_tier\": \"raw\"," >> ${workingJSONFileName}
+		    fi
+		    echo "  \"file_format\": \"hdf5\"," >> ${workingJSONFileName}
+		    echo "  \"file_name\": \"${baseFileName}\"," >> ${workingJSONFileName}
+		    echo "  \"file_type\": \"detector\"," >> ${workingJSONFileName}
+		    if [[ "`echo ${fullFileName} | grep 'transfer_test'`" != "" ]]; then
+			echo "  \"DUNE.campaign\": \"DressRehearsalNov2023\"," >> ${workingJSONFileName}
+		    fi
+		    echo "  \"runs\": [[${run_number},1,\"${offlineRunTypeReallyOpEnv}\"]]" >> ${workingJSONFileName}
+		    echo "}" >> ${workingJSONFileName}
+		else
+		    if [[ $debugLevel -ge 1 ]]; then
+			logMessage "Creating ${jsonFileName} from ${fullFileName} using ${hdf5DumpFullPath} and local modifications."
+		    else
+			logMessage "Creating ${jsonFileName} using ${ourHDF5DumpScript} and local modifications."
+		    fi
+
+		    if [[ $debugLevel -ge 2 ]]; then logMessage "Before the TR (event) numbers are determined"; fi
+		    rm -f ${scratchFile}
+		    #${hdf5DumpFullPath} -H ${fullFileName} | grep GROUP | grep TriggerRecord | sed 's/.*TriggerRecord//' | sed 's/\".*//' > ${scratchFile} 2>/dev/null
+		    ${hdf5DumpFullPath} ${fullFileName} > ${scratchFile} 2>/dev/null
+		    if [[ $debugLevel -ge 2 ]]; then logMessage "After the TR (event) numbers are determined"; fi
+
+		    # if the dumper utility worked, process the results
+		    if [[ $? == 0 ]]; then
+			event_list=`cat ${scratchFile}`
+			#logMessage "event list is ${event_list}"
+			rm -f ${scratchFile}
+
+			IFS=$'\n' trimmed_list1=($(sed 's/0$/TLZ/' <<<"${event_list[*]}"))
+			IFS=$'\n' trimmed_list2=($(sed 's/^0+//' <<<"${trimmed_list1[*]}"))
+			IFS=$'\n' trimmed_list3=($(sed 's/TLZ$/0/' <<<"${trimmed_list2[*]}"))
+			IFS=$'\n' trimmed_list4=($(sed 's/\..*//' <<<"${trimmed_list3[*]}"))
+			IFS=$'\n' sorted_list=($(sort -u -n <<<"${trimmed_list4[*]}"))
+			IFS=$'\n' event_count=($(wc -l <<<"${sorted_list[*]}"))
+			unset IFS
+
+			min_event_num=${sorted_list[0]}
+			max_event_num=${sorted_list[-1]}
+
+			formatted_event_list=`echo "${sorted_list[*]}" | sed 's/ /,/g'`
+			if [[ $debugLevel -ge 2 ]]; then logMessage "Midway through processing the TR (event) numbers"; fi
+
+			echo "{" > ${workingJSONFileName}
+			echo "  \"data_stream\": \"test\"," >> ${workingJSONFileName}
+			if [[ "`echo ${filenamePrefix} | grep '_tp$'`" != "" ]]; then
+			    echo "  \"data_tier\": \"trigprim\"," >> ${workingJSONFileName}
+			else
+			    echo "  \"data_tier\": \"raw\"," >> ${workingJSONFileName}
+			fi
+			echo "  \"event_count\": ${event_count}," >> ${workingJSONFileName}
+			echo "  \"events\": [${formatted_event_list}]," >> ${workingJSONFileName}
+			echo "  \"file_format\": \"hdf5\"," >> ${workingJSONFileName}
+			echo "  \"file_name\": \"${baseFileName}\"," >> ${workingJSONFileName}
+			echo "  \"file_type\": \"detector\"," >> ${workingJSONFileName}
+			if [[ "`echo ${fullFileName} | grep 'transfer_test'`" != "" ]]; then
+			    echo "  \"DUNE.campaign\": \"DressRehearsalNov2023\"," >> ${workingJSONFileName}
+			fi
+			echo "  \"first_event\": ${min_event_num}," >> ${workingJSONFileName}
+			echo "  \"last_event\": ${max_event_num}," >> ${workingJSONFileName}
+			echo "  \"runs\": [[${runNumber},1,\"${offlineRunTypeReallyOpEnv}\"]]" >> ${workingJSONFileName}
+			echo "}" >> ${workingJSONFileName}
+		    else
+			logMessage "ERROR: unable to run ${ourHDF5DumpScript} on \"${fullFileName}\"."
+			rm ${workingJSONFileName}
+		    fi
+		    if [[ $debugLevel -ge 2 ]]; then logMessage "After the TR (event) numbers are processed"; fi
+		fi
+
+		if [[ $debugLevel -ge 2 ]]; then logMessage "Before extra field(s) are added"; fi
+		if [[ -e "${workingJSONFileName}" ]]; then
+		    ${extraFieldCommand} ${fullFileName} ${workingJSONFileName} >/dev/null 2>/dev/null
+		    mv ${workingJSONFileName} ${jsonFileName}
+		fi
+		if [[ $debugLevel -ge 2 ]]; then logMessage "After extra field(s) are added"; fi
+
+		let processed_file_count=$processed_file_count+1
+		processed_one_or_more_files="yes"
+	    fi
+
+	    if [[ $processed_file_count -ge 16 ]]; then break; fi
+	done # loop over the files that have been found
+
+    done # loop over filename prefixes
+
+done # loop until there are no files to be processed
+
+# cleanup
+rm -f ${lockFileDir}/${lockFileName}
+logMessage "Done with $0 for ${dataDirs}."

--- a/scripts/print_values_for_json_metadata.py
+++ b/scripts/print_values_for_json_metadata.py
@@ -30,7 +30,7 @@ def main(filename):
         attr_value = "cosmics"
     print(f'{attr_name} {attr_value}')
 
-    attr_name = "run_is_for_test_purposes"
+    attr_name = "run_was_for_test_purposes"
     try:
         attr_value = h5_file.get_attribute(attr_name)
     except RuntimeError:

--- a/scripts/print_values_for_json_metadata.py
+++ b/scripts/print_values_for_json_metadata.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+from datetime import datetime
+from hdf5libs import HDF5RawDataFile
+
+import click
+import time
+
+@click.command()
+@click.argument('filename', type=click.Path(exists=True))
+
+def main(filename):
+
+    h5_file = HDF5RawDataFile(filename)
+
+    attr_name = "creation_timestamp"
+    value_string = h5_file.get_attribute(attr_name)
+    attr_value = datetime.utcfromtimestamp(float(value_string)/1000.0).isoformat()
+    print(f'{attr_name} {attr_value}')
+    
+    attr_name = "closing_timestamp"
+    value_string = h5_file.get_attribute(attr_name)
+    attr_value = datetime.utcfromtimestamp(float(value_string)/1000.0).isoformat()
+    print(f'{attr_name} {attr_value}')
+
+    attr_name = "offline_data_stream"
+    try:
+        attr_value = h5_file.get_attribute(attr_name)
+    except RuntimeError:
+        attr_value = "cosmics"
+    print(f'{attr_name} {attr_value}')
+
+    attr_name = "run_is_for_test_purposes"
+    try:
+        attr_value = h5_file.get_attribute(attr_name)
+    except RuntimeError:
+        attr_value = "true"
+    print(f'{attr_name} {attr_value}')
+
+    records = h5_file.get_all_record_ids()
+
+    print('=== start of record list')
+    for r in records:
+        print(f'{r[0]}.{r[1]}')
+    print('=== end of record list')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
These changes are part of the work to provide an additional file-transfer metadata field to offline (`DUNE.daq_test`) and to provide more descriptive values in the existing `data_stream` file-transfer metadata field.

The new `print_values_for_json_metadata.py` script will be used at EHN1 as part of reading the HDF5 file Attributes out of each raw data file and creating corresponding metadata fields.

The addition of the `createMetadataFilesForDataN.sh` script to this repo is a first step in providing better tracking of changes to it.

This PR is part of a Deliverable for fddaq-v4.4.0, DUNE-DAQ/daq-deliverables#126, and the new tools depend on changes in other repos, however they can be merged independently