### PR TITLE
Added a check on whether the WIBEth data extends beyond the readout window...

### DIFF
--- a/scripts/wibethdecoder.py
+++ b/scripts/wibethdecoder.py
@@ -79,6 +79,8 @@ def main(filenames, nrecords, nskip, channel_map, print_headers, print_adc_stats
                 frag_hdr = frag.get_header()
                 frag_type = frag.get_fragment_type()
                 frag_ts = frag.get_trigger_timestamp()
+                frag_window_begin = frag.get_window_begin()
+                frag_window_end = frag.get_window_end()
                 if(frag_type!=daqdataformats.FragmentType.kWIBEth):
                     print('\tNot WIBEth fragment type {frag_type}. Continue.')
                     continue
@@ -122,9 +124,13 @@ def main(filenames, nrecords, nskip, channel_map, print_headers, print_adc_stats
                             print(f'\t\tTimestamp diffs: {timestamps_diff_vals}')
                             print(f'\t\tTimestamp diff counts: {timestamps_diff_counts}')
                             print(f'\t\tAverage diff: {np.mean(timestamps_diff)}')
-                            
-                            
-                            
+                            data_extent_before_readout_window = frag_window_begin - timestamps[0]
+                            data_extent_after_readout_window = timestamps[-1] - frag_window_end
+                            print(f'\t\tData extent beyond readout window (before,after): {data_extent_before_readout_window},{data_extent_after_readout_window} (approximate)')
+                            if data_extent_before_readout_window < 0.0 or data_extent_after_readout_window < 0.0:
+                                print(f'\t\t\tWARNING: the WIBEth data does not fully cover the readout window ({frag_window_begin},{frag_window_end})')
+
+
                 if print_adc_stats:
 
                     #unpack adcs into a n_frames x 256 numpy array of uint16

--- a/scripts/wibethdecoder.py
+++ b/scripts/wibethdecoder.py
@@ -127,7 +127,7 @@ def main(filenames, nrecords, nskip, channel_map, print_headers, print_adc_stats
                             data_extent_before_readout_window = frag_window_begin - timestamps[0]
                             data_extent_after_readout_window = timestamps[-1] - frag_window_end
                             print(f'\t\tData extent beyond readout window (before,after): {data_extent_before_readout_window},{data_extent_after_readout_window} (approximate)')
-                            if data_extent_before_readout_window < 0.0 or data_extent_after_readout_window < 0.0:
+                            if data_extent_before_readout_window < 0.0 or data_extent_after_readout_window < -32.0:
                                 print(f'\t\t\tWARNING: the WIBEth data does not fully cover the readout window ({frag_window_begin},{frag_window_end})')
 
 


### PR DESCRIPTION
…to wibethdecoder.py

This is a simple sanity check that can help catch bugs in fetching the WIBEth data that satisfies a DataRequest.

I'm not sure if the wording of the new printout is clear, or if the practice of printing out a WARNING message when something seems wrong is typical in rawdatautils scripts, so feedback on both of those would be good.

A random note is that the subtraction of two very large numbers (timestamps) does not seem to be very exact, hence the "(approximate") qualifier in the new printout.