### PR TITLE
Updated daphne_decoder.py in several ways

### DIFF
--- a/scripts/daphne_decoder.py
+++ b/scripts/daphne_decoder.py
@@ -65,10 +65,10 @@ def print_links(pds_geo_ids):
 @click.option('--det', default='HD_PDS', help='Subdetector string (default: HD_PDS)')
 @click.option('--nrecords', '-n', default=-1, help='How many Trigger Records to process (default: all)')
 @click.option('--nskip', default=0, help='How many Trigger Records to skip (default: 0)')
-@click.option('--summary', is_flag=True, help="Print checks summary")
-@click.option('--check_ts', is_flag=True, help="Print timestamps check")
-@click.option('--adc_stats', is_flag=True, help="Print adc stats")
-@click.option('--print_frame_timestamps', is_flag=True, help="Print individual frame timestamps (can be verbose)")
+@click.option('--summary', is_flag=True, help="Print checks summary (currently broken?)")
+@click.option('--check_ts', is_flag=True, help="Print timestamps check (works for streaming data)")
+@click.option('--adc_stats', is_flag=True, help="Print adc stats (works for streaming data)")
+@click.option('--print_frame_timestamps', is_flag=True, help="Print individual frame timestamps (can be very verbose)")
 
 def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary, print_frame_timestamps):
 
@@ -133,7 +133,6 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary, print_fra
         for gid in pds_geo_ids:
             
             frag     = h5_file.get_frag(r,gid)
-            #geo_info = detchannelmaps.HardwareMapService.parse_geo_id(gid)
             det_link = 0xffff & (gid >> 48);
             det_slot = 0xffff & (gid >> 32);
             det_crate = 0xffff & (gid >> 16);
@@ -150,13 +149,14 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary, print_fra
                 channels   = np_array_channels(frag)
                 n_channels = len(np.unique(channels))
 
-            elif fragType == 13:
+            elif fragType == FragmentType.kDAPHNEStream.value:
 
                 first_frame = fddetdataformats.DAPHNEStreamFrame(frag.get_data())
                 timestamps = np_array_timestamp_stream(frag)
                 adcs       = np_array_adc_stream(frag)
                 channels   = np_array_channels_stream(frag)[0]
                 n_channels = len(np.unique(channels))
+                #print(f'Frame size = {first_frame.sizeof()}, number of timestamps, adcs, channels, channels_in_list = {len(timestamps)}, {len(adcs)}, {len(channels)}, {len(np_array_channels_stream(frag))}')
 
             trigger_stamps.append(frag.get_trigger_timestamp())
 
@@ -189,23 +189,31 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary, print_fra
 
                 print(line)
 
-            if tslot == det_slot:
-                continue
-            else:
-                tslot = det_slot
-                print("")
-
             if (print_frame_timestamps):
+                temp_channels = np_array_channels_stream(frag)
                 temp_dashes_string = "-"*110
                 print(f"    {temp_dashes_string}")
                 print("      --> Frame timestamp details <--")
                 print("      Index  Channel  DTS Timestamp (ticks)  DTS Timestamp (time string)")
                 print(f"    {temp_dashes_string}")
+                loop_counter = 0;
                 for idx in range(len(timestamps)):
+                    if fragType == FragmentType.kDAPHNEStream.value and (idx % 64) != 0:
+                        continue
                     ts_nsec = float(timestamps[idx])/62500000.0
                     time_string = datetime.datetime.fromtimestamp(ts_nsec)
-                    print(f'     {idx:>5}   {channels[idx]:>5}    {timestamps[idx]:>20}    {str(time_string):<26}')
+                    if fragType == FragmentType.kDAPHNEStream.value:
+                        print(f'     {(idx/64):>5}   {temp_channels[loop_counter]}    {timestamps[idx]:>20}    {str(time_string):<26}')
+                    else:
+                        print(f'     {idx:>5}   {channels[idx]:>5}    {timestamps[idx]:>20}    {str(time_string):<26}')
+                    loop_counter += 1
                 print()
+
+            if tslot == det_slot:
+                continue
+            else:
+                tslot = det_slot
+                print("")
 
         print(f"Number of active/total channels \t-- {active_channels:>20}/{scanned_channels}\n")
 

--- a/scripts/daphne_decoder.py
+++ b/scripts/daphne_decoder.py
@@ -13,6 +13,7 @@ from hdf5libs import HDF5RawDataFile
 
 import daqdataformats
 import detdataformats
+import fddetdataformats
 from daqdataformats import FragmentType
 from rawdatautils.unpack.daphne import *
 import detchannelmaps
@@ -42,8 +43,14 @@ def print_links(pds_geo_ids):
     split = " "*6 + "|" + " "*6
     geo_data = [[] for i in range(4)]
     for gid in pds_geo_ids:
-        geo_info = detchannelmaps.HardwareMapService.parse_geo_id(gid)
-        geo_data[geo_info.det_slot].append(geo_info.det_link)
+        #geo_info = detchannelmaps.HardwareMapService.parse_geo_id(gid)
+        det_link = 0xffff & (gid >> 48);
+        det_slot = 0xffff & (gid >> 32);
+        det_crate = 0xffff & (gid >> 16);
+        det_id = 0xffff & gid;
+        subdet = detdataformats.DetID.Subdetector(det_id)
+        det_name = detdataformats.DetID.subdetector_to_string(subdet)
+        geo_data[det_slot].append(det_link)
 
     
     for i in range(len(geo_data)):
@@ -121,53 +128,49 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary):
         for gid in pds_geo_ids:
             
             frag     = h5_file.get_frag(r,gid)
-            geo_info = detchannelmaps.HardwareMapService.parse_geo_id(gid)
+            #geo_info = detchannelmaps.HardwareMapService.parse_geo_id(gid)
+            det_link = 0xffff & (gid >> 48);
+            det_slot = 0xffff & (gid >> 32);
+            det_crate = 0xffff & (gid >> 16);
+            det_id = 0xffff & gid;
+            subdet = detdataformats.DetID.Subdetector(det_id)
+            det_name = detdataformats.DetID.subdetector_to_string(subdet)
             fragType = frag.get_header().fragment_type
-            #print(fragType)
 
-            if fragType == FragmentType.kDAPHNEStream.value:
-
-                timestamps = np_array_timestamp_stream(frag)
-                adcs       = np_array_adc_stream(frag)
-                channels   = np_array_channels_stream(frag)[0]
-                n_channels = len(np.unique(channels))
+            if fragType == FragmentType.kDAPHNE.value:
             
-            elif fragType == FragmentType.kDAPHNE.value or fragType == '3':
-            
+                first_frame = fddetdataformats.DAPHNEFrame(frag.get_data())
                 timestamps = np_array_timestamp(frag)
                 adcs       = np_array_adc(frag)
                 channels   = np_array_channels(frag)
                 n_channels = len(np.unique(channels))
-                #print(n_channels)
 
-            #elif fragType == 13:
-            #elif fragType == FragmentType.kDAPHNEStream.value:
+            elif fragType == 13:
 
-            #    timestamps = np_array_timestamp_stream(frag)
-            #    adcs       = np_array_adc_stream(frag)
-            #    channels   = np_array_channels_stream(frag)[0]
-            #    n_channels = len(np.unique(channels))
+                first_frame = fddetdataformats.DAPHNEStreamFrame(frag.get_data())
+                timestamps = np_array_timestamp_stream(frag)
+                adcs       = np_array_adc_stream(frag)
+                channels   = np_array_channels_stream(frag)[0]
+                n_channels = len(np.unique(channels))
 
             trigger_stamps.append(frag.get_trigger_timestamp())     
 
-            ts_status = f"{bcolors.FAIL}{'Problems':^20}{bcolors.ENDC}"
+            daq_header = first_frame.get_daqheader()
+            print(daq_header,daq_header.version)
 
-            if n_channels == 0:
-                line = f"{geo_info.det_crate:^10} {geo_info.det_slot:^10} {geo_info.det_link:^10} {dmodes[fragType] :^15} {'Empty fragment':^40} "
-                print(line)
+            ts_status = f"{bcolors.FAIL}{'Problems':^20}{bcolors.ENDC}"
 
             for ch_num in range(n_channels):
                 scanned_channels += 1
-                line = f"{geo_info.det_crate:^10} {geo_info.det_slot:^10} {geo_info.det_link:^10} {dmodes[fragType] :^15} {channels[ch_num]:^10} "
+                line = f"{det_crate:^10} {det_slot:^10} {det_link:^10} {dmodes[fragType] :^15} {channels[ch_num]:^10} "
+
+                if np.mean(adcs[:]) > 10:
+                    active_channels += 1
 
                 if adc_stats:
                     if fragType == FragmentType.kDAPHNE.value:
-                        if np.std(adcs[:]) > 10:
-                            active_channels += 1
                         line += f"{np.mean(adcs[:]):^10.2f}  {np.std(adcs[:]):^10.2f} "
                     else:
-                        if np.std(adcs[:, ch_num]) > 10:
-                            active_channels += 1
                         line += f"{np.mean(adcs[:, ch_num]):^10.2f}  {np.std(adcs[:, ch_num]):^10.2f} "
 
                 if check_ts:
@@ -181,10 +184,10 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary):
 
                 print(line)
 
-            if tslot == geo_info.det_slot:
+            if tslot == det_slot:
                 continue
             else:
-                tslot = geo_info.det_slot
+                tslot = det_slot
                 print("")
 
 

--- a/scripts/daphne_decoder.py
+++ b/scripts/daphne_decoder.py
@@ -19,6 +19,7 @@ from rawdatautils.unpack.daphne import *
 import detchannelmaps
 
 import click
+import datetime
 import time
 import numpy as np
 import time
@@ -67,8 +68,9 @@ def print_links(pds_geo_ids):
 @click.option('--summary', is_flag=True, help="Print checks summary")
 @click.option('--check_ts', is_flag=True, help="Print timestamps check")
 @click.option('--adc_stats', is_flag=True, help="Print adc stats")
+@click.option('--print_frame_timestamps', is_flag=True, help="Print individual frame timestamps (can be verbose)")
 
-def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary):
+def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary, print_frame_timestamps):
 
     h5_file   = HDF5RawDataFile(filename)
     records   = h5_file.get_all_record_ids()
@@ -116,8 +118,11 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary):
         if check_ts:
             headline += f" {'TS stats':^17} {'TS Check':^18}"
 
+        trg_ts_nsec = float(h5_file.get_frag(r,pds_geo_ids[0]).get_trigger_timestamp())/62500000.0
+        trg_time_string = datetime.datetime.fromtimestamp(trg_ts_nsec)
+
         print("-"*114)
-        print(f"{'RECORD':>50}: {r[0]:<15} {time.ctime(h5_file.get_frag(r,pds_geo_ids[0]).get_trigger_timestamp()*16 /1e9):^20}")
+        print(f"{'RECORD':>50}: {r[0]:<15} {str(trg_time_string):^26}")
         print("-"*114)
         print(headline)
         print("-"*114)
@@ -153,7 +158,7 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary):
                 channels   = np_array_channels_stream(frag)[0]
                 n_channels = len(np.unique(channels))
 
-            trigger_stamps.append(frag.get_trigger_timestamp())     
+            trigger_stamps.append(frag.get_trigger_timestamp())
 
             daq_header = first_frame.get_daqheader()
             print(daq_header,daq_header.version)
@@ -190,10 +195,19 @@ def main(filename, det, nrecords, nskip, adc_stats, check_ts, summary):
                 tslot = det_slot
                 print("")
 
+            if (print_frame_timestamps):
+                temp_dashes_string = "-"*110
+                print(f"    {temp_dashes_string}")
+                print("      --> Frame timestamp details <--")
+                print("      Index  Channel  DTS Timestamp (ticks)  DTS Timestamp (time string)")
+                print(f"    {temp_dashes_string}")
+                for idx in range(len(timestamps)):
+                    ts_nsec = float(timestamps[idx])/62500000.0
+                    time_string = datetime.datetime.fromtimestamp(ts_nsec)
+                    print(f'     {idx:>5}   {channels[idx]:>5}    {timestamps[idx]:>20}    {str(time_string):<26}')
+                print()
 
         print(f"Number of active/total channels \t-- {active_channels:>20}/{scanned_channels}\n")
-
-        
 
     if summary:
 


### PR DESCRIPTION
The only file/script affected by this PR is `daphne_decoder.py`.  I'm proposing to get these changes into fddaq-v5.3.1, but of course that is open for discussion.

The initial change to this script was to bring forward modifications that were made in the v4 development line after the v5 line branched off.  That helped get this script working again.

Next, I added a `--print_frame_timestamps` option to print out all of the timestamps in each fragment.  I found that very helpful when trying to understand the data that we see in DAPHNE self-triggered fragments.  (The `--print_frame_timestamps` option also works for DAPHNE streaming data, but it can be quite verbose.)

I then looked into which of the features of the `daphne_decoder.py` script work for each of the types of DAPHNE data.  Here is my summary of the current situation:

1. the basic summary that the script prints out for each Fragment in each TriggerRecord
    * This works well for streaming data.
    * The output can be a little confusing/misleading for self-triggered data.  I believe that there is a mismatch between the size of various data structures in the code that needs to be remedied.
2. the output from the `--summary` option
    * this seems to be broken for both types of data
3. the output from the `--check_ts` option
    * this works fine for streaming data
    * this does not work well for self-triggered data, and I'm not sure that it makes sense for self-triggered data
4. the output of the 'adc_stats` option
    * this works fine for streaming data
    * this does not work well for self-triggered data.  Again, the handling of distinct channels seems to get confused here.
5.  the output from the `--print_frame_timestamps` works reasonably well for both types of data

I have updated the "help" text that the script prints out to try to indicate which options work well for which type of data.

I believe that the changes that have been made so far are worthy of being included in v5.3.1, even though there are some additional changes that will need to be made.

