### PR TITLE
update the TDE unpackers, and update the decoder to use the dataclass-based unpacker

### DIFF
--- a/pybindsrc/TDEUnpacker.cpp
+++ b/pybindsrc/TDEUnpacker.cpp
@@ -1,12 +1,12 @@
 /**
- * @file WIBEthUnpacker.cc Fast C++ -> numpy WIBEth format unpacker
+ * @file TDEEthUnpacker.cc Fast C++ -> numpy tDEEth format unpacker
  *
  * This is part of the DUNE DAQ , copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
 
-#include "fddetdataformats/TDE16Frame.hpp"
+#include "fddetdataformats/TDEEthFrame.hpp"
 #include "daqdataformats/Fragment.hpp"
 
 #include <cstdint>
@@ -16,39 +16,84 @@ namespace py = pybind11;
 namespace dunedaq::rawdatautils::tde {
 
 /**
- * @brief Gets number of TDE16Frames in a fragment
+ * @brief Gets number of TDEEthFrames in a fragment
  */
 uint32_t get_n_frames(daqdataformats::Fragment const& frag){
-  return (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::TDE16Frame);
+  return (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::TDEEthFrame);
 }
 
 /**
- * @brief Unpacks data containing TDE16Frames into a numpy array with the
- * timestamps/channel with dimension (number of TDE16Frames)
- * Warning: It doesn't check that nframes is a sensible value (can read out of bounds)
+ * @brief Unpacks data containing TDEEthFrames into a numpy array with the ADC
+ * values and dimension (number of TDEEthFrames, 64)
+ * Warning: It doesn't check that n_frames is a sensible value (can read out of bounds)
  */
-py::array_t<uint64_t> np_array_timestamp_data(daqdataformats::Fragment const& frag){
-  size_t nframes = (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::TDE16Frame);
-  py::array_t<uint64_t> ret(nframes);
-  auto ptr = static_cast<uint64_t*>(ret.request().ptr);
-  for (size_t i=0; i<(size_t)nframes; i++) {
-    auto fr = reinterpret_cast<fddetdataformats::TDE16Frame*>(static_cast<char*>(frag.get_data()) + i * sizeof(fddetdataformats::TDE16Frame));
-    ptr[i] = fr->get_timestamp();
-  }
+py::array_t<uint16_t> np_array_adc_data(void* data, uint32_t n_frames){
 
-  return ret;
+    uint32_t n_ch = fddetdataformats::TDEEthFrame::s_num_channels;
+    uint32_t n_smpl = fddetdataformats::TDEEthFrame::s_time_samples_per_frame;
+
+    py::array_t<uint16_t> result(n_ch * n_smpl * n_frames);
+
+    py::buffer_info buf_res = result.request();
+
+    auto ptr_res = static_cast<uint16_t*>(buf_res.ptr);
+
+    for (size_t i=0; i<n_frames; ++i) {
+
+        auto fr = reinterpret_cast<fddetdataformats::TDEEthFrame*>(
+            static_cast<char*>(data) + i * sizeof(fddetdataformats::TDEEthFrame)
+        );
+
+        for (size_t j=0; j<n_smpl; ++j){
+            for (size_t k=0; k<n_ch; ++k){
+                ptr_res[(n_smpl*n_ch) * i + n_ch*j + k] = fr->get_adc(k, j);
+            }
+        }
+    }
+    result.resize({n_frames*n_smpl, n_ch});
+
+    return result;
 }
 
-py::array_t<uint64_t> np_array_channel_data(daqdataformats::Fragment const& frag){
-  size_t nframes = (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::TDE16Frame);
-  py::array_t<uint64_t> ret(nframes);
-  auto ptr = static_cast<uint64_t*>(ret.request().ptr);
-  for (size_t i=0; i<(size_t)nframes; i++) {
-    auto fr = reinterpret_cast<fddetdataformats::TDE16Frame*>(static_cast<char*>(frag.get_data()) + i * sizeof(fddetdataformats::TDE16Frame));
-    ptr[i] = fr->get_channel();
-  }
+/**
+ * @brief Unpacks data containing TDEEthFrames into a numpy array with the
+ * timestamps with dimension (number of TDEEthFrames)
+ * Warning: It doesn't check that n_frames is a sensible value (can read out of bounds)
+ */
+py::array_t<long double> np_array_timestamp_data(void* data, uint32_t n_frames){
 
-  return ret;
+    uint32_t n_smpl = fddetdataformats::TDEEthFrame::s_time_samples_per_frame;
+
+    py::array_t<long double> result(n_smpl*n_frames);
+
+    auto ptr = static_cast<long double*>(result.request().ptr);
+
+    for (size_t i=0; i<n_frames; ++i) {
+        auto fr = reinterpret_cast<fddetdataformats::TDEEthFrame*>(
+            static_cast<char*>(data) + i * sizeof(fddetdataformats::TDEEthFrame)
+        );
+        long double ts_0 = fr->get_timestamp();
+        for(size_t j=0; j<n_smpl; ++j )
+            ptr[i*n_smpl+j] = ts_0+31.25*j;
+    }
+
+    return result;
+}
+
+/**
+ * @brief Unpacks a Fragment containing TDEEthFrames into a numpy array with the
+ * ADC values and dimension (number of TDEEthFrames in the Fragment, 64)
+ */
+py::array_t<uint16_t> np_array_adc(daqdataformats::Fragment const& frag){
+    return np_array_adc_data(frag.get_data(), get_n_frames(frag));
+}
+
+/**
+ * @brief Unpacks the timestamps in a Fragment containing TDEEthFrames into a numpy
+ * array with dimension (number of TDEEthFrames in the Fragment)
+ */
+py::array_t<long double> np_array_timestamp(daqdataformats::Fragment const& frag){
+    return np_array_timestamp_data(frag.get_data(), get_n_frames(frag));
 }
 
 } // namespace dunedaq::rawdatautils::tde // NOLINT

--- a/pybindsrc/unpack.cpp
+++ b/pybindsrc/unpack.cpp
@@ -10,7 +10,7 @@
 #include "fddetdataformats/WIB2Frame.hpp"
 #include "fddetdataformats/DAPHNEFrame.hpp"
 #include "fddetdataformats/WIBEthFrame.hpp"
-#include "fddetdataformats/TDE16Frame.hpp"
+#include "fddetdataformats/TDEEthFrame.hpp"
 #include "daqdataformats/Fragment.hpp"
 
 #include <pybind11/numpy.h>
@@ -81,9 +81,10 @@ namespace daphne {
 
 namespace tde {
   extern uint32_t get_n_frames(daqdataformats::Fragment const& frag);
-  extern py::array_t<uint64_t> np_array_timestamp(daqdataformats::Fragment const& frag);
-  extern py::array_t<uint64_t> np_array_timestamp_data(daqdataformats::Fragment const& frag);
-  extern py::array_t<uint64_t> np_array_channel_data(daqdataformats::Fragment const& frag);
+  extern py::array_t<uint16_t> np_array_adc(daqdataformats::Fragment const& frag);
+  extern py::array_t<uint16_t> np_array_adc_data(void* data, uint32_t n_frames);
+  extern py::array_t<long double> np_array_timestamp(daqdataformats::Fragment const& frag);
+  extern py::array_t<long double> np_array_timestamp_data(void* data, uint32_t n_frames);
 
 }
 
@@ -134,8 +135,10 @@ register_unpack(py::module& m) {
 
   py::module_ tde_module = m.def_submodule("tde");
   tde_module.def("get_n_frames", &tde::get_n_frames);
+  tde_module.def("np_array_adc", &tde::np_array_adc);
+  tde_module.def("np_array_timestamp", &tde::np_array_timestamp);
+  tde_module.def("np_array_adc_data", &tde::np_array_adc_data);
   tde_module.def("np_array_timestamp_data", &tde::np_array_timestamp_data);
-  tde_module.def("np_array_channel_data", &tde::np_array_channel_data);
 
 }
 

--- a/python/rawdatautils/unpack/dataclasses.py
+++ b/python/rawdatautils/unpack/dataclasses.py
@@ -282,6 +282,65 @@ class WIBEthWaveformData(WIBEthChannelDataBase):
     fft_mag: np.ndarray
 
 @dataclass(order=True)
+class TDEEthHeaderData(FragmentDataBase):
+
+    #first frame only
+    channel_id: int
+    tde_header: int
+    version: int
+
+    #_idx arrays contain indices where value has changed from previous
+    #_vals arrays contain the values at those indices
+    errors_vals: np.ndarray
+    errors_idx: np.ndarray
+
+    #these take differences between successive values,
+    #and then, as above, look for differences in those differences
+    #store first value so the full array can be reconstructed
+    timestamp_dts_diff_vals: np.ndarray[int, np.float128]
+    timestamp_dts_diff_idx: np.ndarray
+    timestamp_dts_first: int
+
+    tai_time_diff_vals: np.ndarray[int, np.float128]
+    tai_time_diff_idx: np.ndarray
+    tai_time_first: int
+
+    n_frames: int
+    n_channels: int
+    sampling_period: int
+
+@dataclass(order=True)
+class TDEEthChannelDataBase(FragmentDataBase):
+
+    channel: int
+    plane: int
+    element: int
+    tde_chan: int
+
+    @classmethod
+    def index_names(cls):
+        return [ "run","trigger","sequence","src_id","channel" ]
+
+    def index_values(self):
+        return [ self.run, self.trigger, self.sequence, self.src_id, self.channel ]
+
+@dataclass(order=True)
+class TDEEthAnalysisData(TDEEthChannelDataBase):
+
+    adc_mean: float
+    adc_rms: float
+    adc_max: int
+    adc_min: int
+    adc_median: float
+
+@dataclass(order=True)
+class TDEEthWaveformData(TDEEthChannelDataBase):
+
+    timestamps: np.ndarray[int, np.float128]
+    adcs: np.ndarray
+    fft_mag: np.ndarray
+
+@dataclass(order=True)
 class DAPHNEStreamHeaderData(FragmentDataBase):
 
     n_channels: int

--- a/python/rawdatautils/unpack/utils.py
+++ b/python/rawdatautils/unpack/utils.py
@@ -18,6 +18,15 @@ import h5py
 import numpy as np
 import numpy.fft
 
+class NullChannelMap:
+
+    def get_offline_channel_from_crate_slot_stream_chan(crate, slot, stream, ch):
+        return (ch + (stream << 10 ) + (slot << 18 ) + (crate << 22))
+    def get_plane_from_offline_channel(ch):
+        return -1
+    def get_tpc_element_from_offline_channel(ch):
+        return "Null"
+
 class Unpacker:
 
     is_fragment_unpacker = False
@@ -150,9 +159,9 @@ class TriggerPrimitiveUnpacker(TriggerDataUnpacker):
 
     trg_obj = trgdataformats.TriggerPrimitive
 
-    def __init__(self,channel_map):
+    def __init__(self,channel_map=None):
         super().__init__()
-        self.channel_map = detchannelmaps.make_map(channel_map)
+        self.channel_map = detchannelmaps.make_map(channel_map) if channel_map else NullChannelMap
 
     def get_n_obj(self,frag):
         return int(frag.get_data_size()/self.trg_obj.sizeof())
@@ -189,9 +198,9 @@ class TriggerActivityUnpacker(TriggerDataUnpacker):
 
     trg_obj = trgdataformats.TriggerActivity
 
-    def __init__(self,channel_map):
+    def __init__(self,channel_map=None):
         super().__init__()
-        self.channel_map = detchannelmaps.make_map(channel_map)
+        self.channel_map = detchannelmaps.make_map(channel_map) if channel_map else NullChannelMap
 
     def get_n_obj(self,frag):
         frag_data_size = frag.get_data_size()
@@ -264,9 +273,9 @@ class TriggerCandidateUnpacker(TriggerDataUnpacker):
 
     trg_obj = trgdataformats.TriggerCandidate
 
-    def __init__(self,channel_map):
+    def __init__(self,channel_map=None):
         super().__init__()
-        self.channel_map = detchannelmaps.make_map(channel_map)
+        self.channel_map = detchannelmaps.make_map(channel_map) if channel_map else NullChannelMap
 
     def get_n_obj(self,frag):
         frag_data_size = frag.get_data_size()
@@ -388,9 +397,9 @@ class WIBEthUnpacker(DetectorFragmentUnpacker):
     SAMPLING_PERIOD = 32
     N_CHANNELS_PER_FRAME = 64
     
-    def __init__(self,channel_map,ana_data_prescale=1,wvfm_data_prescale=None):
+    def __init__(self,channel_map=None,ana_data_prescale=1,wvfm_data_prescale=None):
         super().__init__(ana_data_prescale=ana_data_prescale, wvfm_data_prescale=wvfm_data_prescale)
-        self.channel_map = detchannelmaps.make_map(channel_map)
+        self.channel_map = detchannelmaps.make_map(channel_map) if channel_map else NullChannelMap
 
     def get_n_obj(self,frag):
         return self.unpacker.get_n_frames(frag)
@@ -556,8 +565,136 @@ class WIBEthUnpacker(DetectorFragmentUnpacker):
                                              adcs=adcs[:,i_ch],
                                              fft_mag=ffts[:,i_ch]) for i_ch in range(self.N_CHANNELS_PER_FRAME) ]
         
-        return ana_data, wvfm_data                
+        return ana_data, wvfm_data
 
+
+class TDEEthUnpacker(DetectorFragmentUnpacker):
+
+    unpacker = rawdatautils.unpack.tde
+    frame_obj = fddetdataformats.TDEEthFrame
+
+    SAMPLING_PERIOD = 31.25
+    N_CHANNELS_PER_FRAME = 64
+
+    def __init__(self,channel_map=None,ana_data_prescale=1,wvfm_data_prescale=None):
+        super().__init__(ana_data_prescale=ana_data_prescale, wvfm_data_prescale=wvfm_data_prescale)
+        self.channel_map = detchannelmaps.make_map(channel_map) if channel_map else NullChannelMap
+
+    def get_n_obj(self,frag):
+        return self.unpacker.get_n_frames(frag)
+
+    def get_daq_header_version(self,frag):
+        return self.frame_obj(frag.get_data()).get_daqheader().version
+
+    def get_timestamp_first(self,frag):
+        return self.frame_obj(frag.get_data()).get_timestamp()
+
+    def get_det_data_version(self,frag):
+        return self.frame_obj(frag.get_data()).get_tdeheader().version
+
+    def get_det_crate_slot_stream(self,frag):
+        dh = self.frame_obj(frag.get_data()).get_daqheader()
+        return dh.det_id, dh.crate_id, dh.slot_id, dh.stream_id
+
+    def get_det_header_data(self,frag):
+        frh = frag.get_header()
+
+        n_frames = self.get_n_obj(frag)
+
+        errors_arr = np.empty(n_frames)
+        tai_time_arr = np.empty(n_frames)
+
+        for i in range(n_frames):
+            tdeh = self.frame_obj(frag.get_data(i*self.frame_obj.sizeof())).get_tdeheader()
+
+            errors_arr[i] = tdeh.tde_errors
+            tai_time_arr[i] = tdeh.TAItime
+
+        errors_change_idx, errors_change_val, _ = sparsify_array_diff_locs_and_vals(errors_arr)
+
+        tai_time_diff = np.diff(tai_time_arr)
+        tai_time_diff_change_idx, tai_time_diff_change_val, _ = sparsify_array_diff_locs_and_vals(tai_time_diff)
+
+        ts_arr = self.unpacker.np_array_timestamp(frag)
+        ts_diff_change_idx, ts_diff_change_val, _ = sparsify_array_diff_locs_and_vals(np.diff(ts_arr))
+
+        tdeh = self.frame_obj(frag.get_data()).get_tdeheader()
+        ts_diff_vals, ts_diff_counts = np.unique(np.diff(self.unpacker.np_array_timestamp(frag)),return_counts=True)
+        return [ TDEEthHeaderData(run=frh.run_number,
+                                  trigger=frh.trigger_number,
+                                  sequence=frh.sequence_number,
+                                  src_id=frh.element_id.id,
+                                  channel_id=tdeh.channel,
+                                  tde_header=tdeh.tde_header,
+                                  version=tdeh.version,
+                                  errors_vals=errors_change_val, errors_idx=errors_change_idx,
+                                  tai_time_diff_vals=tai_time_diff_change_val,
+                                  tai_time_diff_idx=tai_time_diff_change_idx,
+                                  tai_time_first=tai_time_arr[0],
+                                  timestamp_dts_diff_vals=ts_diff_change_val,
+                                  timestamp_dts_diff_idx=ts_diff_change_idx,
+                                  timestamp_dts_first=ts_arr[0],
+                                  n_frames=n_frames,
+                                  n_channels=self.N_CHANNELS_PER_FRAME,
+                                  sampling_period=self.SAMPLING_PERIOD) ]
+
+    def get_det_data_all(self,frag):
+        frh = frag.get_header()
+        trigger_number = frh.trigger_number
+
+        get_ana_data = (self.ana_data_prescale is not None and (trigger_number % self.ana_data_prescale)==0)
+        get_wvfm_data = (self.wvfm_data_prescale is not None and (trigger_number % self.wvfm_data_prescale)==0)
+
+        #print(f'\t\tTrigger number {trigger_number}: get_ana_data? {get_ana_data} get_wvfm_data? {get_wvfm_data}')
+
+        if not (get_ana_data or get_wvfm_data):
+            return None,None
+
+        ana_data = None
+        wvfm_data = None
+
+        adcs = self.unpacker.np_array_adc(frag)
+        _, crate, slot, stream = self.get_det_crate_slot_stream(frag)
+        channels = [ self.channel_map.get_offline_channel_from_crate_slot_stream_chan(crate, slot, stream, c) for c in range(self.N_CHANNELS_PER_FRAME) ]
+        planes = [ self.channel_map.get_plane_from_offline_channel(uc) for uc in channels ]
+        elements = [ self.channel_map.get_tpc_element_from_offline_channel(uc) for uc in channels ]
+        tde_chans = range(self.N_CHANNELS_PER_FRAME)
+
+        if get_ana_data:
+            adc_mean = np.mean(adcs,axis=0)
+            adc_rms = np.std(adcs,axis=0)
+            adc_max = np.max(adcs,axis=0)
+            adc_min = np.min(adcs,axis=0)
+            adc_median = np.median(adcs,axis=0)
+            ana_data = [ TDEEthAnalysisData(run=frh.run_number,
+                                            trigger=frh.trigger_number,
+                                            sequence=frh.sequence_number,
+                                            src_id=frh.element_id.id,
+                                            channel=channels[i_ch],
+                                            plane=planes[i_ch],
+                                            element=elements[i_ch],
+                                            tde_chan=tde_chans[i_ch],
+                                            adc_mean=adc_mean[i_ch],
+                                            adc_rms=adc_rms[i_ch],
+                                            adc_max=adc_max[i_ch],
+                                            adc_min=adc_min[i_ch],
+                                            adc_median=adc_median[i_ch]) for i_ch in range(self.N_CHANNELS_PER_FRAME) ]
+        if get_wvfm_data:
+            timestamps = self.unpacker.np_array_timestamp(frag)
+            ffts = np.abs(np.fft.rfft(adcs,axis=0))
+            wvfm_data = [ TDEEthWaveformData(run=frh.run_number,
+                                             trigger=frh.trigger_number,
+                                             sequence=frh.sequence_number,
+                                             src_id=frh.element_id.id,
+                                             channel=channels[i_ch],
+                                             plane=planes[i_ch],
+                                             element=elements[i_ch],
+                                             tde_chan=tde_chans[i_ch],
+                                             timestamps=timestamps,
+                                             adcs=adcs[:,i_ch],
+                                             fft_mag=ffts[:,i_ch]) for i_ch in range(self.N_CHANNELS_PER_FRAME) ]
+
+        return ana_data, wvfm_data
 
 class DAPHNEStreamUnpacker(DetectorFragmentUnpacker):
 

--- a/scripts/tdedecoder.py
+++ b/scripts/tdedecoder.py
@@ -5,6 +5,7 @@ from hdf5libs import HDF5RawDataFile
 import daqdataformats
 import detdataformats
 from rawdatautils.unpack.tde import *
+from rawdatautils.unpack.utils import *
 import detchannelmaps
 
 import click
@@ -16,10 +17,12 @@ import numpy as np
 @click.argument('filename', type=click.Path(exists=True))
 @click.option('--nrecords', '-n', default=-1, help='How many Trigger Records to process (default: all)')
 @click.option('--nskip', default=0, help='How many Trigger Records to skip (default: 0)')
-@click.option('--print-headers', is_flag=True, help="Print TDE16Frame headers")
+@click.option('--print-headers', is_flag=True, help="Print all TDE frame headers (default only first frame)")
+@click.option('--print-adc-stats', is_flag=True, help="Print ADC Pedestals/RMS")
+@click.option('--print-wvfm-samples', default=0, help='How many samples in each waveform to print.')
 @click.option('--det', default='VD_Top_TPC', help='Subdetector string (default: VD_TopTPC)')
 
-def main(filename, nrecords, nskip, print_headers, det):
+def main(filename, nrecords, nskip, print_headers, print_adc_stats, print_wvfm_samples, det):
 
     h5_file = HDF5RawDataFile(filename)
 
@@ -41,36 +44,62 @@ def main(filename, nrecords, nskip, print_headers, det):
         records_to_process = records[nskip:nrecords]
     print(f'Will process {len(records_to_process)} of {len(records)} records.')
 
+    unpacker = TDEEthUnpacker(channel_map=None,ana_data_prescale=1,wvfm_data_prescale=1)
+
     for r in records_to_process:
 
         print(f'Processing (Record Number,Sequence Number)=({r[0],r[1]})')
-        wib_geo_ids = h5_file.get_geo_ids_for_subdetector(r,detdataformats.DetID.string_to_subdetector(det))
+        geo_ids = h5_file.get_geo_ids_for_subdetector(r,detdataformats.DetID.string_to_subdetector(det))
 
-        for gid in wib_geo_ids:
-            geo_info = detchannelmaps.HardwareMapService.parse_geo_id(gid)
-            subdet = detdataformats.DetID.Subdetector(geo_info.det_id)
+        for gid in geo_ids:
+
+            det_stream = 0xffff & (gid >> 48);
+            det_slot = 0xffff & (gid >> 32);
+            det_crate = 0xffff & (gid >> 16);
+            det_id = 0xffff & gid;
+            subdet = detdataformats.DetID.Subdetector(det_id)
             det_name = detdataformats.DetID.subdetector_to_string(subdet)
-            print(f'\tProcessing subdetector {det_name}, crate {geo_info.det_crate}, slot {geo_info.det_slot}, link {geo_info.det_link}')
+            print(f'\tProcessing subdetector {det_name}, '
+                  f'crate {det_crate}, '
+                  f'slot {det_slot}, '
+                  f'stream {det_stream}')
 
+            #get the fragment
             frag = h5_file.get_frag(r,gid)
-            frag_hdr = frag.get_header()
-            frag_ts = frag.get_trigger_timestamp()
 
-            print(f'\tTrigger timestamp for fragment is {frag_ts}')
-            times = np_array_timestamp_data(frag);
-            channels = np_array_channel_data(frag);
-            n_frames = get_n_frames(frag);
-            print(f'\tFound {n_frames} TDE Frames.')
+            #perform unpacking of fragment and detector header info
+            frag_header = unpacker.get_frh_data(frag)[0]
 
-            
-            #n_frames = 5
-            #print header info
-            if print_headers :
-                for i in range (0,n_frames):
-                    print(f'{times[i]=} {channels[i]=}')
+            print('\t',frag_header)
 
-            print("\n")
-        
+            n_frames = unpacker.get_n_obj(frag)
+            if n_frames==0:
+                print('Found no TDE frames in this fragment.')
+                continue
+
+            daq_header_data = unpacker.get_daq_header_data(frag)
+            tde_header_data = unpacker.get_det_header_data(frag)
+
+            for i_tdeh, tdeh in enumerate(tde_header_data):
+                print(f'\tDAQ header {i_tdeh}: ',daq_header_data[i_tdeh])
+                print(f'\tTDE header {i_tdeh}: ',tdeh)
+                if not print_headers: break
+
+            tde_ana_data, tde_wvfm_data = unpacker.get_det_data_all(frag)
+
+            if print_adc_stats:
+                for tde_ana in tde_ana_data:
+                    print(f'\t\tTDE channel {tde_ana.channel} adc stats:')
+                    print('\t\t',tde_ana)
+
+            if print_wvfm_samples:
+                for tde_wvfm in tde_wvfm_data:
+                    print(f'\t\tTDE channel {tde_wvfm.channel} waveform:')
+                    for i_sample in range(print_wvfm_samples):
+                        ts_str = np.format_float_positional(tde_wvfm.timestamps[i_sample])
+                        print(f'\t\t\t {i_sample:>5}:  ts={ts_str:<25}  val={tde_wvfm.adcs[i_sample]}')
+
+
     #end record loop
 
     print(f'Processed all requested records')

--- a/scripts/tdedecoder.py
+++ b/scripts/tdedecoder.py
@@ -17,12 +17,11 @@ import numpy as np
 @click.argument('filename', type=click.Path(exists=True))
 @click.option('--nrecords', '-n', default=-1, help='How many Trigger Records to process (default: all)')
 @click.option('--nskip', default=0, help='How many Trigger Records to skip (default: 0)')
-@click.option('--print-headers', is_flag=True, help="Print all TDE frame headers (default only first frame)")
 @click.option('--print-adc-stats', is_flag=True, help="Print ADC Pedestals/RMS")
 @click.option('--print-wvfm-samples', default=0, help='How many samples in each waveform to print.')
 @click.option('--det', default='VD_Top_TPC', help='Subdetector string (default: VD_TopTPC)')
 
-def main(filename, nrecords, nskip, print_headers, print_adc_stats, print_wvfm_samples, det):
+def main(filename, nrecords, nskip, print_adc_stats, print_wvfm_samples, det):
 
     h5_file = HDF5RawDataFile(filename)
 
@@ -73,8 +72,8 @@ def main(filename, nrecords, nskip, print_headers, print_adc_stats, print_wvfm_s
             print('\t',frag_header)
 
             n_frames = unpacker.get_n_obj(frag)
+            print(f'Found {n_frames} TDE frames in this fragment.')
             if n_frames==0:
-                print('Found no TDE frames in this fragment.')
                 continue
 
             daq_header_data = unpacker.get_daq_header_data(frag)
@@ -82,8 +81,7 @@ def main(filename, nrecords, nskip, print_headers, print_adc_stats, print_wvfm_s
 
             for i_tdeh, tdeh in enumerate(tde_header_data):
                 print(f'\tDAQ header {i_tdeh}: ',daq_header_data[i_tdeh])
-                print(f'\tTDE header {i_tdeh}: ',tdeh)
-                if not print_headers: break
+                print(f'\tTDE header info: ',tdeh)
 
             tde_ana_data, tde_wvfm_data = unpacker.get_det_data_all(frag)
 


### PR DESCRIPTION
This PR updates unpacking of TDE data.

The existing unpacker was still using the old 'TDE16Frame' object and had function calls that were inconsistent with the unpackers for the WIBEth.

This PR:
- Updates to using the TDEEthFrame
- Changes the TDEUnpacker.cpp to match the behavior of WIBEth. Note: timestamp array unpacking (to provide the timestamp per adc value) requires use of long doubles given the sampling rate of the adc values (31.25 DTS ticks per ADC).
- Creates TDEEthHeaderData, TDEEthAnalysisData, and TDEEthWaveformData dataclasses as unpacking targets.
- Adds a TDEEthUnpacker to unpack fragment data into those dataclasses.
- Updates the tde_decoder to make use of these tools, and adds some options for printing adc stats and waveform information. Note the tde_decoder is intended mostly to be an example of how to unpack, and doesn't exhaust all types of data to look at.

The PR is made against the v5.3.x patch branches, though could also be merged with develop.

To test, setup an area either based on fddaq-v5.3.1 or a recent nightly, pull down this rawdatautils branch, and then run `tde_decoder.py` over file with TDE data. A recent file with data from the test crate is available (thanks to @alessandrothea ) at `np04-srv-004:/data0/test/np02vd_raw_run035756_0000_df-s04-d0_dw_0_20250407T135443.hdf5`. Example command to run from np04-srv-004:

```
tdedecoder.py -n 1 /data0/test/np02vd_raw_run035756_0000_df-s04-d0_dw_0_20250407T135443.hdf5 --print-wvfm-samples 10 --print-adc-stats
```