### PR TITLE
Pretty-er printing of dataclasses

### DIFF
--- a/python/rawdatautils/unpack/dataclasses.py
+++ b/python/rawdatautils/unpack/dataclasses.py
@@ -71,6 +71,9 @@ class RecordDataBase():
     def index_values(self):
         return [ self.run, self.trigger, self.sequence ]
 
+    def __str__(self):
+        return f"{self.__class__.__name__}({', '.join(f'{name}={getattr(self, name)}' for name in self.index_names())})"
+
 @dataclass(order=True)
 class SourceIDData(RecordDataBase):
     src_id: int
@@ -78,6 +81,14 @@ class SourceIDData(RecordDataBase):
     subsystem_str: str
     version: int
     
+    def __str__(self):
+        base_str = super().__str__()
+
+        additional_fields = [f"src_id={self.src_id}",
+                             f"subsystem={self.subsystem} ('{self.subsystem_str}')",
+                             f"version={self.version}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 @dataclass(order=True)
 class FragmentDataBase(RecordDataBase):
     src_id: int
@@ -107,6 +118,18 @@ class TriggerRecordData(RecordDataBase):
         self.trigger_time = dts_to_datetime(self.trigger_timestamp_dts)
         self.trigger_type_bits = [ trgdataformats.TriggerCandidateData.Type(i) for i in range(64) if (self.trigger_type & (1<<i))!=0 ]
     
+    def __str__(self):
+        base_str = super().__str__()
+
+        additional_fields = [f"trigger_timestamp={self.trigger_timestamp_dts} ({self.trigger_time})", 
+                             f"trigger_type={self.trigger_type} ({self.trigger_type_bits})",
+                             f"n_fragments={self.n_fragments}",
+                             f"n_requested_components={self.n_requested_components}",
+                             f"max_sequence_number={self.max_sequence_number}",
+                             f"total_size_bytes={self.total_size_bytes}",
+                             f"error_bits={self.error_bits}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+    
 
 @dataclass(order=True)
 class FragmentHeaderData(FragmentDataBase):
@@ -127,6 +150,21 @@ class FragmentHeaderData(FragmentDataBase):
         self.trigger_time = dts_to_datetime(self.trigger_timestamp_dts)
         self.window_begin_time = dts_to_datetime(self.window_begin_dts)
         self.window_end_time = dts_to_datetime(self.window_end_dts)
+
+    def __str__(self):
+        base_str = super().__str__()
+
+        fr_type = daqdataformats.FragmentType(self.fragment_type)
+        subdet = detdataformats.DetID.subdetector_to_string(detdataformats.DetID.Subdetector(self.det_id))
+        additional_fields = [f"trigger_timestamp={self.trigger_timestamp_dts}",
+                             f"window [begin,end)=[{self.window_begin_dts},{self.window_end_dts})",
+                             f"det_id={self.det_id} ('{subdet}')",
+                             f"fragment_type={self.fragment_type} ('{daqdataformats.fragment_type_to_string(fr_type)}')",
+                             f"total_size_bytes={self.total_size_bytes}",
+                             f"data_size_bytes={self.data_size_bytes}",
+                             f"error_bits={self.error_bits}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 
 @dataclass(order=True)
 class TriggerHeaderData(FragmentDataBase):
@@ -149,6 +187,22 @@ class TriggerPrimitiveData(FragmentDataBase):
     flag: int
     id_ta: int
 
+    def __str__(self):
+        base_str = super().__str__()
+        subdet = detdataformats.DetID.subdetector_to_string(detdataformats.DetID.Subdetector(self.detid))
+
+        additional_fields = [f"channel={self.channel}",
+                             f"(plane,element)=({self.plane},{self.element})",
+                             f"time_start={self.time_start}",
+                             f"samples_to_peak={self.samples_to_peak}",
+                             f"samples_over_threshold={self.samples_over_threshold}",
+                             f"adc_integral={self.adc_integral}",
+                             f"adc_peak={self.adc_peak}",
+                             f"detid={self.detid} ('{subdet}')",
+                             f"flag={self.flag}",
+                             f"id_ta={self.id_ta}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 @dataclass(order=True)
 class TriggerActivityData(FragmentDataBase):
 
@@ -170,6 +224,26 @@ class TriggerActivityData(FragmentDataBase):
     id: int
     id_tc: int
 
+    def __str__(self):
+        base_str = super().__str__()
+        subdet = detdataformats.DetID.subdetector_to_string(detdataformats.DetID.Subdetector(self.detid))
+        tatype = trgdataformats.TriggerActivityData.Type(self.ta_type)
+        taalg = trgdataformats.TriggerActivityData.Algorithm(self.algorithm)
+
+        additional_fields = [f"id={self.id}",
+                             f"channel (start,peak,end)=({self.channel_start},{self.channel_peak},{self.channel_end})",
+                             f"(plane,element)=({self.plane},{self.element})",
+                             f"time_activity={self.time_activity}",
+                             f"time (start,peak,end)=({self.time_start},{self.time_peak},{self.time_end})",
+                             f"adc_integral={self.adc_integral}",
+                             f"adc_peak={self.adc_peak}",
+                             f"detid={self.detid} ('{subdet}')",
+                             f"ta_type={self.ta_type} ('{tatype})",
+                             f"algorithm={self.algorithm} ('{taalg})",
+                             f"n_tps={self.n_tps}",
+                             f"id_tc={self.id_tc}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 @dataclass(order=True)
 class TriggerCandidateData(FragmentDataBase):
 
@@ -181,6 +255,21 @@ class TriggerCandidateData(FragmentDataBase):
     algorithm: int
     n_tas: int
     id: int
+
+    def __str__(self):
+        base_str = super().__str__()
+        subdet = detdataformats.DetID.subdetector_to_string(detdataformats.DetID.Subdetector(self.detid))
+        tctype = trgdataformats.TriggerCandidateData.Type(self.tc_type)
+        tcalg = trgdataformats.TriggerCandidateData.Algorithm(self.algorithm)
+
+        additional_fields = [f"id={self.id}",
+                             f"time_candidate={self.time_candidate}",
+                             f"time (start,end)=({self.time_start},{self.time_end})",
+                             f"detid={self.detid} ('{subdet}')",
+                             f"tc_type={self.ta_type} ('{tctype})",
+                             f"algorithm={self.algorithm} ('{tcalg})",
+                             f"n_tas={self.n_tas}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
 
 @dataclass(order=True)
 class DAQHeaderData(FragmentDataBase):
@@ -197,6 +286,17 @@ class DAQHeaderData(FragmentDataBase):
 
     def __post_init__(self):
         self.timestamp_first_time = dts_to_datetime(self.timestamp_first_dts)
+
+    def __str__(self):
+        base_str = super().__str__()
+        subdet = detdataformats.DetID.subdetector_to_string(detdataformats.DetID.Subdetector(self.det_id))
+        additional_fields = [f"n_obj={self.n_obj}",
+                             f"first_timestamp={self.timestamp_first_dts}",
+                             f"det_id={self.det_id} ('{subdet}')",
+                             f"(crate_id,slot_id,stream_id)=({self.crate_id},{self.slot_id},{self.stream_id})",
+                             f"daq_header_version={self.daq_header_version}",
+                             f"det_data_version={self.det_data_version}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
 
 @dataclass(order=True)
 class WIBEthHeaderData(FragmentDataBase):
@@ -250,6 +350,25 @@ class WIBEthHeaderData(FragmentDataBase):
     n_channels: int
     sampling_period: int
 
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"n_frames={self.n_frames}",
+                             f"n_channels={self.n_channels}",
+                             f"sampling_period={self.sampling_period}",
+                             f"femb_id={self.femb_id}",
+                             f"coldata_id={self.colddata_id}",
+                             f"version={self.version}",
+                             f"first_timestamp={self.timestamp_dts_first}"]
+        additional_field_names = ["timestamp_dts_diff",
+                                  "colddata_timestamp_0_diff","colddata_timestamp_1_diff",
+                                  "cd","crc_err","link_valid","lol","wib_sync","femb_sync",
+                                  "pulser","calibration","ready","context"]
+        for name in additional_field_names:
+            vals_name = f'{name}_vals'
+            idx_name = f'{name}_idx'
+            additional_fields.append(f"{name}={getattr(self,vals_name)} (idx={getattr(self,idx_name)})")                         
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 @dataclass(order=True)
 class WIBEthChannelDataBase(FragmentDataBase):
     
@@ -274,12 +393,28 @@ class WIBEthAnalysisData(WIBEthChannelDataBase):
     adc_min: int
     adc_median: float
 
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"adc_mean={self.adc_mean}",
+                             f"adc_rms={self.adc_rms}",
+                             f"adc_max={self.adc_max}",
+                             f"adc_min={self.adc_min}",
+                             f"adc_median={self.adc_median}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 @dataclass(order=True)
 class WIBEthWaveformData(WIBEthChannelDataBase):
 
     timestamps: np.ndarray
     adcs: np.ndarray
     fft_mag: np.ndarray
+
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"timestamps={self.timestamps}",
+                             f"adcs={self.adcs}",
+                             f"fft_mag={self.fft_mag}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
 
 @dataclass(order=True)
 class TDEEthHeaderData(FragmentDataBase):
@@ -309,6 +444,23 @@ class TDEEthHeaderData(FragmentDataBase):
     n_channels: int
     sampling_period: int
 
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"n_frames={self.n_frames}",
+                             f"n_channels={self.n_channels}",
+                             f"sampling_period={self.sampling_period}",
+                             f"channel_id={self.channel_id}",
+                             f"tde_header={self.tde_header}",
+                             f"version={self.version}",
+                             f"first_timestamp={self.timestamp_first_dts}",
+                             f"tai_time_first={self.tai_time_first}"]
+        additional_field_names = ["timestamp_dts_diff","tai_time_diff","errors"]
+        for name in additional_field_names:
+            vals_name = f'{name}_vals'
+            idx_name = f'{name}_idx'
+            additional_fields.append(f"{name}={getattr(self,vals_name)} (idx={getattr(self,idx_name)})")                         
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 @dataclass(order=True)
 class TDEEthChannelDataBase(FragmentDataBase):
 
@@ -333,12 +485,28 @@ class TDEEthAnalysisData(TDEEthChannelDataBase):
     adc_min: int
     adc_median: float
 
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"adc_mean={self.adc_mean}",
+                             f"adc_rms={self.adc_rms}",
+                             f"adc_max={self.adc_max}",
+                             f"adc_min={self.adc_min}",
+                             f"adc_median={self.adc_median}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 @dataclass(order=True)
 class TDEEthWaveformData(TDEEthChannelDataBase):
 
     timestamps: np.ndarray[int, np.float128]
     adcs: np.ndarray
     fft_mag: np.ndarray
+
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"timestamps={self.timestamps}",
+                             f"adcs={self.adcs}",
+                             f"fft_mag={self.fft_mag}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
 
 @dataclass(order=True)
 class DAPHNEStreamHeaderData(FragmentDataBase):
@@ -347,6 +515,13 @@ class DAPHNEStreamHeaderData(FragmentDataBase):
     sampling_period: int
     ts_diffs_vals: np.ndarray
     ts_diffs_counts: np.ndarray
+
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"n_channels={self.n_channels}",
+                             f"sampling_period={self.sampling_period}",
+                             f"ts_diffs_vals={self.ts_diffs_vals} (counts={self.ts_diffs_counts})"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
 
 @dataclass(order=True)
 class DAPHNEChannelDataBase(FragmentDataBase):
@@ -370,7 +545,16 @@ class DAPHNEStreamAnalysisData(DAPHNEChannelDataBase):
     adc_max: int
     adc_min: int
     adc_median: float
-    
+
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"adc_mean={self.adc_mean}",
+                             f"adc_rms={self.adc_rms}",
+                             f"adc_max={self.adc_max}",
+                             f"adc_min={self.adc_min}",
+                             f"adc_median={self.adc_median}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 @dataclass(order=True)
 class DAPHNEStreamWaveformData(DAPHNEChannelDataBase):
 
@@ -378,7 +562,13 @@ class DAPHNEStreamWaveformData(DAPHNEChannelDataBase):
     adcs: np.ndarray
     fft_mag: np.ndarray
 
-
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"timestamps={self.timestamps}",
+                             f"adcs={self.adcs}",
+                             f"fft_mag={self.fft_mag}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+    
 @dataclass(order=True)
 class DAPHNEAnalysisData(DAPHNEChannelDataBase):
 
@@ -393,10 +583,30 @@ class DAPHNEAnalysisData(DAPHNEChannelDataBase):
     adc_median: float
     timestamp_max_dts: int
     timestamp_min_dts: int
-    
+
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"timestamp_dts={self.timestamp_dts}",
+                             f"trigger_sample_value={self.trigger_sample_value}",
+                             f"baseline={self.baseline}",
+                             f"threshold={self.threshold}",
+                             f"adc_mean={self.adc_mean}",
+                             f"adc_rms={self.adc_rms}",
+                             f"adc_max={self.adc_max} (timestamp={self.timestamp_max_dts})",
+                             f"adc_min={self.adc_min} (timestamp={self.timestamp_min_dts})",
+                             f"adc_median={self.adc_median}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"
+
 @dataclass(order=True)
 class DAPHNEWaveformData(DAPHNEChannelDataBase):
 
     timestamp_dts: int
     timestamps: np.ndarray
     adcs: np.ndarray
+
+    def __str__(self):
+        base_str = super().__str__()
+        additional_fields = [f"timestamp_dts={self.timestamp_dts}",
+                             f"timestamps={self.timestamps}",
+                             f"adcs={self.adcs}"]
+        return f"{base_str}: [{', '.join(additional_fields)}]"

--- a/scripts/tpcdecoder.py
+++ b/scripts/tpcdecoder.py
@@ -47,6 +47,7 @@ def main(filename, nrecords, nskip, print_adc_stats, print_wvfm_samples, det, ch
         openv_channel_map="PD2VDTPCChannelMap"
     else:
         print(f'Unknown operational_environment ({op_env}). Will use specified channel-map {channel_map}')
+        openv_channel_map=channel_map
  
     if openv_channel_map!=channel_map and channel_map is not None:
         print(f'Operational environment {op_env} suggests channel map {openv_channel_map}, not {channel_map}.')

--- a/scripts/tpcdecoder.py
+++ b/scripts/tpcdecoder.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+from hdf5libs import HDF5RawDataFile
+import h5py
+
+import daqdataformats
+import detdataformats
+import detchannelmaps
+
+from rawdatautils.unpack.dataclasses import *
+import rawdatautils.unpack.utils
+
+import click
+import time
+import numpy as np
+
+
+@click.command()
+@click.argument('filename', type=click.Path(exists=True))
+@click.option('--nrecords', '-n', default=-1, help='How many Trigger Records to process (default: all)')
+@click.option('--nskip', default=0, help='How many Trigger Records to skip (default: 0)')
+@click.option('--print-adc-stats', is_flag=True, help="Print ADC Pedestals/RMS")
+@click.option('--print-wvfm-samples', default=0, help='How many samples in each waveform to print.')
+@click.option('--det', multiple=True, default=['VD_TopTPC','VD_BottomTPC'], help='Subdetector string (default: VD_TopTPC,VD_BottomTPC)')
+@click.option('--channel-map', default=None, help="Channel map to load (default: None)")
+
+def main(filename, nrecords, nskip, print_adc_stats, print_wvfm_samples, det, channel_map):
+
+    #get the file
+    h5_file = HDF5RawDataFile(filename)
+
+    #get the run number and operational environment out of the file attributes
+    with h5py.File(h5_file.get_file_name(), 'r') as f:
+        run_number = f.attrs["run_number"]
+        op_env = f.attrs["operational_environment"]
+        print(f'Processing file {h5_file.get_file_name()}. run_number={run_number}, operational_environemnt={op_env}')
+
+    #fill in appropriate channel name if we can tell from operational_environment
+    openv_channel_map=None
+    if op_env=="np04hd":
+        openv_channel_map="PD2HDTPCChannelMap"
+    elif op_env=="np04hdcoldbox":
+        openv_channel_map="HDColdboxTPCChannelMap"
+    elif op_env=="iceberghd" or op_env=="iceberg" or op_env=="icebergvd":
+        openv_channel_map="ICEBERGChannelMap"
+    elif op_env=="np02vd":
+        openv_channel_map="PD2VDTPCChannelMap"
+    else:
+        print(f'Unknown operational_environment ({op_env}). Will use specified channel-map {channel_map}')
+ 
+    if openv_channel_map!=channel_map and channel_map is not None:
+        print(f'Operational environment {op_env} suggests channel map {openv_channel_map}, not {channel_map}.')
+        print(f'Please correct (or do not specify channel map and use operational environment to select). Exiting...')
+        return
+
+    channel_map=openv_channel_map
+    print(f'Using channel_map={channel_map}')
+
+    #get list of records in the file
+    records = h5_file.get_all_record_ids()
+
+    #pick which records to process based on cmdline inputs
+    if nskip > len(records):
+        print(f'Requested records to skip {nskip} is greater than number of records {len(records)}. Exiting...')
+        return
+    if nrecords>0:
+        if (nskip+nrecords)>len(records):
+            nrecords=-1
+        else:
+            nrecords=nskip+nrecords
+    records_to_process = []
+    if nrecords==-1:
+        records_to_process = records[nskip:]
+    else:
+        records_to_process = records[nskip:nrecords]
+    print(f'Will process {len(records_to_process)} of {len(records)} records.')
+
+    #loop over the records
+    for r in records_to_process:
+
+        #get the record index and print it
+        record_index = RecordDataBase(run=run_number,trigger=r[0],sequence=r[1])
+        print(f'Processing ',record_index)
+
+        #get the trigger record header data and print it
+        trh = h5_file.get_trh(record_index.trigger,record_index.sequence)
+        n_frags = len(h5_file.get_fragment_dataset_paths(record_index.trigger,record_index.sequence))
+        trh_data = rawdatautils.unpack.utils.TriggerRecordHeaderUnpacker().get_trh_data(trh,n_frags)[0]
+        print(trh_data)
+
+        # Process each detector type in the list
+        for det_type in det:
+
+            #get all geo_ids for this type
+            geo_ids = h5_file.get_geo_ids_for_subdetector(r,detdataformats.DetID.string_to_subdetector(det_type))
+            
+            #loop through geo_ids
+            for gid in geo_ids:
+
+                #print basic information from geo id
+                det_stream = 0xffff & (gid >> 48);
+                det_slot = 0xffff & (gid >> 32);
+                det_crate = 0xffff & (gid >> 16);
+                det_id = 0xffff & gid;
+                subdet = detdataformats.DetID.Subdetector(det_id)
+                det_name = detdataformats.DetID.subdetector_to_string(subdet)
+                print(f'\tProcessing subdetector {det_name}, '
+                      f'crate {det_crate}, '
+                      f'slot {det_slot}, '
+                      f'stream {det_stream}')
+
+                #get the fragment
+                frag = h5_file.get_frag(r,gid)
+
+                unpacker = rawdatautils.unpack.utils.FragmentUnpacker()
+                frag_header = unpacker.get_frh_data(frag)[0]
+                print('\t',frag_header)
+
+                #get fragment type and pick the correct unpacker
+                frag_type = frag.get_fragment_type()
+                if frag_type==daqdataformats.FragmentType.kWIBEth:
+                    unpacker = rawdatautils.unpack.utils.WIBEthUnpacker(channel_map=channel_map,ana_data_prescale=1,wvfm_data_prescale=1)
+                elif frag_type==daqdataformats.FragmentType.kTDEEth:
+                    unpacker = rawdatautils.unpack.utils.TDEEthUnpacker(channel_map=channel_map,ana_data_prescale=1,wvfm_data_prescale=1)
+                else:
+                    print(f'\tUnknown fragment type {frag_type}. Continuing...')
+                    continue
+
+                n_frames = unpacker.get_n_obj(frag)
+                print(f'Found {n_frames} frames in this fragment.')
+                if n_frames==0:
+                    continue
+
+                daq_header_data = unpacker.get_daq_header_data(frag)
+                det_header_data = unpacker.get_det_header_data(frag)
+
+                for i_deth, deth in enumerate(det_header_data):
+                    print(f'\t',daq_header_data[i_deth])
+                    print(f'\t',deth)
+
+                det_ana_data, det_wvfm_data = unpacker.get_det_data_all(frag)
+
+                if print_adc_stats:
+                    for det_ana in det_ana_data:
+#                        print(f'\t\tChannel {det_ana.channel} adc stats:')
+                        print('\t\t',det_ana)
+
+                if print_wvfm_samples:
+                    for det_wvfm in det_wvfm_data:
+                        print(f'\t\tChannel {det_wvfm.channel} waveform:')
+                        for i_sample in range(print_wvfm_samples):
+                            ts_str = np.format_float_positional(det_wvfm.timestamps[i_sample])
+                            print(f'\t\t\t {i_sample:>5}:  ts={ts_str:<25}  val={det_wvfm.adcs[i_sample]}')
+
+
+    #end record loop
+
+    print(f'Processed all requested records')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Description

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Fixes #107

This introduces `__str__` methods on all the rawdatautils python unpacking dataclasses to improve the formatting of the standard printing. This is intended to work with any written recent data. 

It also includes a new `tpcdecoder.py` script that can be used to print out either TDE or WIB data, using these dataclasses and direct printing methods for demonstration.

There is a proliferation of decoder scripts that deserves some cleanup: e.g. older WIB decoders could likely be removed. I'll. make a separate issue for that.

_Please also include instructions for how a reviewer can test your changes._
On a file containing TPC data, do:
```
tpcdecoder.py -n 1 --print-adc-stats --print-wvfm-samples 10 <file_name>
```
You should see something like:
```
Using channel_map=PD2VDTPCChannelMap
Will process 1 of 40 records.
Processing  RecordDataBase(run=40491, trigger=1, sequence=0)
TriggerRecordData(run=40491, trigger=1, sequence=0): [trigger_timestamp=110190341754338800 (2025-11-13 14:51:08+00:00), trigger_type=16 ([<Typ
e.kRandom: 4>]), n_fragments=103, n_requested_components=103, max_sequence_number=0, total_size_bytes=3360, error_bits=0]
        Processing subdetector VD_BottomTPC, crate 11, slot 2, stream 3
         FragmentHeaderData(run=40491, trigger=1, sequence=0, src_id=519): [trigger_timestamp=110190341754338800, window [begin,end)=[11019034
1754182550,110190341754495050), det_id=10 ('VD_BottomTPC'), fragment_type=12 ('WIBEth'), total_size_bytes=1108872, data_size_bytes=1108800, er
ror_bits=0]
Found 154 frames in this fragment.
         DAQHeaderData(run=40491, trigger=1, sequence=0, src_id=519): [n_obj=154, first_timestamp=110190341754181643, det_id=10 ('VD_BottomTPC
'), (crate_id,slot_id,stream_id)=(11,2,3), daq_header_version=0, det_data_version=5]
         WIBEthHeaderData(run=40491, trigger=1, sequence=0, src_id=519): [n_frames=154, n_channels=64, sampling_period=32, femb_id=1, coldata_
id=1, version=5, first_timestamp=110190341754181643, timestamp_dts_diff=[32] (idx=[0]), colddata_timestamp_0_diff=[2048.] (idx=[0]), colddata_
timestamp_1_diff=[2048.] (idx=[0]), cd=[0.] (idx=[0]), crc_err=[0.] (idx=[0]), link_valid=[3.] (idx=[0]), lol=[0.] (idx=[0]), wib_sync=[1.] (i
dx=[0]), femb_sync=[3.] (idx=[0]), pulser=[0.] (idx=[0]), calibration=[0.] (idx=[0]), ready=[0.] (idx=[0]), context=[0.] (idx=[0])]
                 WIBEthAnalysisData(run=40491, trigger=1, sequence=0, src_id=519, channel=1404): [adc_mean=8047.343039772727, adc_rms=2.924114
337006354, adc_max=8058, adc_min=8036, adc_median=8047.0]
                 WIBEthAnalysisData(run=40491, trigger=1, sequence=0, src_id=519, channel=2417): [adc_mean=577.4447037337662, adc_rms=17.79236
8332922102, adc_max=1037, adc_min=552, adc_median=577.0]
                 WIBEthAnalysisData(run=40491, trigger=1, sequence=0, src_id=519, channel=1405): [adc_mean=7826.932832792208, adc_rms=2.910940
222983143, adc_max=7838, adc_min=7816, adc_median=7827.0]
                 WIBEthAnalysisData(run=40491, trigger=1, sequence=0, src_id=519, channel=2420): [adc_mean=646.7593344155844, adc_rms=17.27339
7050403805, adc_max=1056, adc_min=612, adc_median=646.0]
                 WIBEthAnalysisData(run=40491, trigger=1, sequence=0, src_id=519, channel=1406): [adc_mean=8024.227374188312, adc_rms=2.895316
668062328, adc_max=8034, adc_min=8013, adc_median=8024.0]
...
                Channel 1404 waveform:
                             0:  ts=110190341754181650.        val=8045
                             1:  ts=110190341754181680.        val=8047
                             2:  ts=110190341754181710.        val=8047
                             3:  ts=110190341754181740.        val=8049
                             4:  ts=110190341754181780.        val=8046
                             5:  ts=110190341754181810.        val=8046
                             6:  ts=110190341754181840.        val=8049
                             7:  ts=110190341754181870.        val=8049
                             8:  ts=110190341754181900.        val=8051
                             9:  ts=110190341754181940.        val=8048
                Channel 2417 waveform:
                             0:  ts=110190341754181650.        val=581
                             1:  ts=110190341754181680.        val=582
                             2:  ts=110190341754181710.        val=581
                             3:  ts=110190341754181740.        val=580
                             4:  ts=110190341754181780.        val=579
                             5:  ts=110190341754181810.        val=576
                             6:  ts=110190341754181840.        val=575
                             7:  ts=110190341754181870.        val=578
                             8:  ts=110190341754181900.        val=580
                             9:  ts=110190341754181940.        val=578
...
```
One can also run the `daphne_decoder.py` on a suitable file with PDS data and see some of these new print statements in action.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

I haven't explicitly run any tests above as these changes wouldn't affect any existing tests.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

