### PR TITLE
Johnfreeman/prep release merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-project(rawdatautils VERSION 2.5.0)
+project(rawdatautils VERSION 2.6.0)
 
 find_package(daq-cmake REQUIRED)
 find_package(fmt REQUIRED)

--- a/pybindsrc/DAPHNEEthUnpacker.cpp
+++ b/pybindsrc/DAPHNEEthUnpacker.cpp
@@ -1,0 +1,213 @@
+/**
+ * @file DAPHNEEthUnpacker.cc Fast C++ -> numpy DAPHNE format unpacker
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "fddetdataformats/DAPHNEEthFrame.hpp"
+#include "fddetdataformats/DAPHNEEthStreamFrame.hpp"
+#include "daqdataformats/Fragment.hpp"
+
+#include <cstdint>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+namespace dunedaq::rawdatautils::daphneeth {
+
+/**                                                                                                                                                                                                                
+ * @brief Gets number of DAPHNEFrames in a fragment                                                                                                                                                                
+ */
+uint32_t get_n_frames(daqdataformats::Fragment const& frag){
+  return (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::DAPHNEEthFrame);
+}
+
+/**                                                                                                                                                                                                                
+ * @brief Gets number of DAPHNEStreamFrames in a fragment                                                                                                                                                          
+ */
+uint32_t get_n_frames_stream(daqdataformats::Fragment const& frag){
+  return (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::DAPHNEEthStreamFrame);
+}
+
+
+/**                                                                                                                                                                                                                
+ * @brief Unpacks channel numbers for DAPHNEEthStreamFrames into a numpy array with dimensions
+ * (nframes, s_channels_per_frame)                                                                                                                                                                                                                                  
+ */
+
+py::array_t<uint8_t> np_array_channels_stream_data(void* data, int nframes){
+
+  const auto channels_per_daphne  = fddetdataformats::DAPHNEEthStreamFrame::s_num_channels;
+  py::array_t<uint8_t> channels(channels_per_daphne * nframes);
+  auto ptr = static_cast<uint8_t*>(channels.request().ptr);
+
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::DAPHNEEthStreamFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::DAPHNEEthStreamFrame));
+
+    ptr[i*channels_per_daphne + 0] = fr->get_channel0();
+    ptr[i*channels_per_daphne + 1] = fr->get_channel1();
+    ptr[i*channels_per_daphne + 2] = fr->get_channel2();
+    ptr[i*channels_per_daphne + 3] = fr->get_channel3();
+
+  }   
+  channels.resize({nframes, channels_per_daphne});
+
+  return channels; 
+}
+
+/**                                                                                                                                                                                                                
+ * @brief Unpacks channel numbers for DAPHNEFrames into a numpy array with dimensions
+ * (nframes)                                                                                                                                                                                                                                  
+ */
+py::array_t<uint8_t> np_array_channels_data(void* data, int nframes){
+
+  py::array_t<uint8_t> channels(nframes);
+  auto ptr = static_cast<uint8_t*>(channels.request().ptr);
+
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::DAPHNEEthFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::DAPHNEEthFrame));
+    ptr[i] = fr->get_channel();
+  }
+
+  return channels;
+}
+
+/**                                                                                                                                                                                                                
+ * @brief Unpacks channel numbers for Fragment that contains DAPHNEFrames into a numpy array with dimensions                                                                                                                                                                                                                   */
+py::array_t<uint8_t> np_array_channels(daqdataformats::Fragment& frag){
+  return np_array_channels_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::DAPHNEEthFrame));
+}
+
+/**                                                                                                                                                                                                                
+ * @brief Unpacks channel numbers for Fragment that contains DAPHNEStreamFrames into a numpy array with dimensions                                                                                                                                                                                                            
+ */
+py::array_t<uint8_t> np_array_channels_stream(daqdataformats::Fragment& frag){
+  return np_array_channels_stream_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::DAPHNEEthStreamFrame));
+}
+
+
+/**
+ * @brief Unpacks data containing DAPHNEFrames into a numpy array with the ADC
+ * values and dimension (number of DAPHNEFrames, channels_per_daphne)
+ * Warning: It doesn't check that nframes is a sensible value (can read out of bounds)
+ */
+py::array_t<uint16_t> np_array_adc_data(void* data, int nframes){
+  
+  const auto adcs_per_channel     = fddetdataformats::DAPHNEEthFrame::s_num_adcs;
+
+  py::array_t<uint16_t> ret(nframes * adcs_per_channel);
+  auto ptr = static_cast<uint16_t*>(ret.request().ptr);
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::DAPHNEEthFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::DAPHNEEthFrame));
+    for (size_t j=0; j<adcs_per_channel; ++j) {
+      ptr[i*adcs_per_channel + j] = fr->get_adc(j);
+    }
+    //for (size_t j=0; j<channels_per_daphne; ++j)
+    
+  }
+  ret.resize({nframes, adcs_per_channel});
+
+  return ret;
+}
+
+/**                                                                                                                                                                                                                
+ * @brief Unpacks data containing DAPHNEStreamFrames into a numpy array with the ADC                                                                                                                               
+ * values and dimension (number of DAPHNEStreamFrames * adcs_per_channel (64), channels_per_frame (4))                                                                                                             
+ * Warning: It doesn't check that nframes is a sensible value (can read out of bounds)                                                                                                                             
+ */
+py::array_t<uint16_t> np_array_adc_stream_data(void* data, int nframes){
+
+  const auto channels_per_daphne  = fddetdataformats::DAPHNEEthStreamFrame::s_num_channels;
+  const auto adcs_per_channel     = fddetdataformats::DAPHNEEthStreamFrame::s_adcs_per_channel;
+
+  
+  py::array_t<uint16_t> ret(channels_per_daphne * nframes * adcs_per_channel);
+  auto ptr = static_cast<uint16_t*>(ret.request().ptr);
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::DAPHNEEthStreamFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::DAPHNEEthStreamFrame));
+    for (size_t j=0; j<adcs_per_channel; ++j)
+      for (size_t k=0; k<channels_per_daphne; ++k)
+        ptr[channels_per_daphne * (adcs_per_channel * i + j) + k] = fr->get_adc(j,k);
+  }
+  ret.resize({nframes*adcs_per_channel, channels_per_daphne});
+
+  return ret;
+}
+
+/**
+ * @brief Unpacks data containing DAPHNEFrames into a numpy array with the
+ * timestamps with dimension (number of DAPHNEFrames)
+ * Warning: It doesn't check that nframes is a sensible value (can read out of bounds)
+ */
+
+py::array_t<uint64_t> np_array_timestamp_data(void* data, int nframes){
+
+  py::array_t<uint64_t> ret(nframes);
+  auto ptr = static_cast<uint64_t*>(ret.request().ptr);
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::DAPHNEEthFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::DAPHNEEthFrame));
+    ptr[i] = fr->get_timestamp();
+  }
+
+  return ret;
+}
+
+/**                                                                                                                                                                                                                
+ * @brief Unpacks data containing DAPHNEStreamFrames into a numpy array with the                                                                                                                                   
+ * timestamps with dimension (number of DAPHNEStreamFrames)                                                                                                                                                        
+ * Warning: It doesn't check that nframes is a sensible value (can read out of bounds)                                                                                                                             
+ */
+py::array_t<uint64_t> np_array_timestamp_stream_data(void* data, int nframes) {
+
+  const auto adcs_per_channel = fddetdataformats::DAPHNEEthStreamFrame::s_adcs_per_channel;
+  const size_t ticks_per_adc = 1;
+
+  py::array_t<uint64_t> ret(nframes*adcs_per_channel);
+
+  auto ptr = static_cast<uint64_t*>(ret.request().ptr);
+  for (size_t i=0; i<(size_t)nframes; ++i) {
+    auto fr = reinterpret_cast<fddetdataformats::DAPHNEEthStreamFrame*>(static_cast<char*>(data) + i * sizeof(fddetdataformats::DAPHNEEthStreamFrame));
+    for (size_t j=0; j<adcs_per_channel; ++j)
+      ptr[i*adcs_per_channel+j] = fr->get_timestamp()+j*ticks_per_adc;
+  }
+
+  return ret;
+}
+
+
+/**
+ * @brief Unpacks a Fragment containing DAPHNEFrames into a numpy array with the
+ * ADC values and dimension (number of DAPHNEFrames in the Fragment, 320)
+ */
+py::array_t<uint16_t> np_array_adc(daqdataformats::Fragment& frag){
+  return np_array_adc_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::DAPHNEEthFrame));
+}
+
+/**                                                                                                                                                                                                                
+ * @brief Unpacks a Fragment containing DAPHNEStreamFrames into a numpy array with the                                                                                                                             
+ * ADC values and dimension (number of DAPHNEStreamFrames in the Fragment, 4)                                                                                                                                      
+ */
+py::array_t<uint16_t> np_array_adc_stream(daqdataformats::Fragment& frag){
+  return np_array_adc_stream_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::DAPHNEEthStreamFrame));
+}
+
+
+/**
+ * @brief Unpacks the timestamps in a Fragment containing WIBFrames into a numpy
+ * array with dimension (number of DAPHNEFrames in the Fragment)
+ */
+py::array_t<uint64_t> np_array_timestamp(daqdataformats::Fragment& frag){
+  return np_array_timestamp_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::DAPHNEEthFrame));
+}
+
+/**                                                                                                                                                                                                                
+ * @brief Unpacks the timestamps in a Fragment containing DAPHNEStreamFrames into a numpy                                                                                                                          
+ * array with dimension (number of DAPHNEStreamFrames in the Fragment)                                                                                                                                             
+ */
+py::array_t<uint64_t> np_array_timestamp_stream(daqdataformats::Fragment& frag){
+  return np_array_timestamp_stream_data(frag.get_data(), (frag.get_size() - sizeof(daqdataformats::FragmentHeader)) / sizeof(fddetdataformats::DAPHNEEthStreamFrame));
+}
+
+
+} // namespace dunedaq::rawdatautils::daphne // NOLINT

--- a/pybindsrc/unpack.cpp
+++ b/pybindsrc/unpack.cpp
@@ -9,6 +9,8 @@
 #include "fddetdataformats/WIBFrame.hpp"
 #include "fddetdataformats/WIB2Frame.hpp"
 #include "fddetdataformats/DAPHNEFrame.hpp"
+#include "fddetdataformats/DAPHNEEthFrame.hpp"
+#include "fddetdataformats/DAPHNEEthStreamFrame.hpp"
 #include "fddetdataformats/WIBEthFrame.hpp"
 #include "fddetdataformats/TDEEthFrame.hpp"
 #include "daqdataformats/Fragment.hpp"
@@ -78,6 +80,24 @@ namespace daphne {
 
 }
 
+namespace daphneeth {
+  extern uint32_t get_n_frames(daqdataformats::Fragment const& frag);
+  extern py::array_t<uint16_t> np_array_adc(daqdataformats::Fragment& frag);
+  extern py::array_t<uint8_t> np_array_channels(daqdataformats::Fragment& frag);
+  extern py::array_t<uint16_t> np_array_adc_data(void* data, int nframes);
+  extern py::array_t<uint64_t> np_array_timestamp(daqdataformats::Fragment& frag);
+  extern py::array_t<uint64_t> np_array_timestamp_data(void* data, int nframes);
+  extern py::array_t<uint8_t> np_array_channels_data(void* data, int nframes);
+
+  extern uint32_t get_n_frames_stream(daqdataformats::Fragment const& frag);
+  extern py::array_t<uint16_t> np_array_adc_stream(daqdataformats::Fragment& frag);
+  extern py::array_t<uint8_t> np_array_channels_stream(daqdataformats::Fragment& frag);
+  extern py::array_t<uint16_t> np_array_adc_stream_data(void* data, int nframes);
+  extern py::array_t<uint64_t> np_array_timestamp_stream(daqdataformats::Fragment& frag);
+  extern py::array_t<uint64_t> np_array_timestamp_stream_data(void* data, int nframes);
+  extern py::array_t<uint8_t> np_array_channels_stream_data(void* data, int nframes);
+
+}
 
 namespace tde {
   extern uint32_t get_n_frames(daqdataformats::Fragment const& frag);

--- a/pybindsrc/unpack.cpp
+++ b/pybindsrc/unpack.cpp
@@ -153,6 +153,23 @@ register_unpack(py::module& m) {
   daphne_module.def("np_array_channels_stream_data", &daphne::np_array_channels_stream_data);
   daphne_module.def("np_array_channels_stream", &daphne::np_array_channels_stream);
 
+  py::module_ daphneeth_module = m.def_submodule("daphneeth");
+  daphneeth_module.def("get_n_frames", &daphneeth::get_n_frames);
+  daphneeth_module.def("np_array_adc", &daphneeth::np_array_adc);
+  daphneeth_module.def("np_array_timestamp", &daphneeth::np_array_timestamp);
+  daphneeth_module.def("np_array_adc_data", &daphneeth::np_array_adc_data);
+  daphneeth_module.def("np_array_timestamp_data", &daphneeth::np_array_timestamp_data);
+  daphneeth_module.def("np_array_channels_data", &daphneeth::np_array_channels_data);
+  daphneeth_module.def("np_array_channels", &daphneeth::np_array_channels);
+
+  daphneeth_module.def("get_n_frames_stream", &daphneeth::get_n_frames_stream);
+  daphneeth_module.def("np_array_adc_stream", &daphneeth::np_array_adc_stream);
+  daphneeth_module.def("np_array_timestamp_stream", &daphneeth::np_array_timestamp_stream);
+  daphneeth_module.def("np_array_adc_stream_data", &daphneeth::np_array_adc_stream_data);
+  daphneeth_module.def("np_array_timestamp_stream_data", &daphneeth::np_array_timestamp_stream_data);
+  daphneeth_module.def("np_array_channels_stream_data", &daphneeth::np_array_channels_stream_data);
+  daphneeth_module.def("np_array_channels_stream", &daphneeth::np_array_channels_stream);
+  
   py::module_ tde_module = m.def_submodule("tde");
   tde_module.def("get_n_frames", &tde::get_n_frames);
   tde_module.def("np_array_adc", &tde::np_array_adc);

--- a/python/rawdatautils/unpack/daphneeth/__init__.py
+++ b/python/rawdatautils/unpack/daphneeth/__init__.py
@@ -1,0 +1,1 @@
+from ..._daq_rawdatautils_py.unpack.daphneeth import *

--- a/python/rawdatautils/unpack/utils.py
+++ b/python/rawdatautils/unpack/utils.py
@@ -746,7 +746,7 @@ class DAPHNEStreamUnpacker(DetectorFragmentUnpacker):
 
     def get_det_header_data(self,frag):
         frh = frag.get_header()
-        dh = self.frame_obj(frag.get_data()).get_header()
+        #dh = self.frame_obj(frag.get_data()).get_header()
         ts_diffs_vals, ts_diffs_counts = np.unique(np.diff( np.array(self.unpacker.np_array_timestamp_stream(frag), dtype=np.int64)), return_counts=True)
         return [ DAPHNEStreamHeaderData(run=frh.run_number,
                                         trigger=frh.trigger_number,
@@ -810,6 +810,10 @@ class DAPHNEStreamUnpacker(DetectorFragmentUnpacker):
 class DAPHNEEthStreamUnpacker(DAPHNEStreamUnpacker):
     unpacker = rawdatautils.unpack.daphneeth
     frame_obj = fddetdataformats.DAPHNEStreamFrame
+
+    def get_det_crate_slot_stream(self,frag):
+        dh = self.frame_obj(frag.get_data()).get_daqheader()
+        return dh.det_id, dh.crate_id, dh.slot_id, dh.stream_id
 
 class DAPHNEUnpacker(DetectorFragmentUnpacker):
 
@@ -908,4 +912,7 @@ class DAPHNEEthUnpacker(DAPHNEUnpacker):
     unpacker = rawdatautils.unpack.daphneeth
     frame_obj = fddetdataformats.DAPHNEEthFrame
 
+    def get_det_crate_slot_stream(self,frag):
+        dh = self.frame_obj(frag.get_data()).get_daqheader()
+        return dh.det_id, dh.crate_id, dh.slot_id, dh.stream_id
 

--- a/python/rawdatautils/unpack/utils.py
+++ b/python/rawdatautils/unpack/utils.py
@@ -12,6 +12,7 @@ import detchannelmaps
 from rawdatautils.unpack.dataclasses import *
 import rawdatautils.unpack.wibeth
 import rawdatautils.unpack.daphne
+import rawdatautils.unpack.daphneeth
 import h5py
 
 #analysis imports
@@ -806,6 +807,9 @@ class DAPHNEStreamUnpacker(DetectorFragmentUnpacker):
                                                    fft_mag=ffts[:,i_ch]) for i_ch in range(self.N_CHANNELS_PER_FRAME) ]
         return ana_data, wvfm_data
 
+class DAPHNEEthStreamUnpacker(DAPHNEStreamUnpacker):
+    unpacker = rawdatautils.unpack.daphneeth
+    frame_obj = fddetdataformats.DAPHNEStreamFrame
 
 class DAPHNEUnpacker(DetectorFragmentUnpacker):
 
@@ -900,5 +904,8 @@ class DAPHNEUnpacker(DetectorFragmentUnpacker):
 
         return ana_data, wvfm_data
 
+class DAPHNEEthUnpacker(DAPHNEUnpacker):
+    unpacker = rawdatautils.unpack.daphneeth
+    frame_obj = fddetdataformats.DAPHNEEthFrame
 
 

--- a/scripts/daphne_decoder.py
+++ b/scripts/daphne_decoder.py
@@ -96,6 +96,8 @@ def main(filename, det, nrecords, nskip, channel_map, adc_stats, print_wvfm_samp
 
     unpacker_stream = DAPHNEStreamUnpacker(channel_map=channel_map,ana_data_prescale=1,wvfm_data_prescale=1)
     unpacker_slftrg = DAPHNEUnpacker(channel_map=channel_map,ana_data_prescale=1,wvfm_data_prescale=1)
+    unpacker_eth_stream = DAPHNEEthStreamUnpacker(channel_map=channel_map,ana_data_prescale=1,wvfm_data_prescale=1)
+    unpacker_eth_slftrg = DAPHNEEthUnpacker(channel_map=channel_map,ana_data_prescale=1,wvfm_data_prescale=1)
 
 
     #have channel numbers per geoid in here
@@ -131,9 +133,15 @@ def main(filename, det, nrecords, nskip, channel_map, adc_stats, print_wvfm_samp
             fragType = frag.get_header().fragment_type
             fragType_string = daqdataformats.fragment_type_to_string(daqdataformats.FragmentType(fragType))
 
-            is_selftrigger = (fragType==FragmentType.kDAPHNE.value)
+            is_selftrigger = (fragType==FragmentType.kDAPHNE.value or fragType==FragmentType.kDAPHNEEth.value)
+            is_eth = (fragType==FragmentType.kDAPHNEEth.value or fragType==FragmentType.kDAPHNEEthStream.value)
 
-            unpacker = unpacker_slftrg if is_selftrigger else unpacker_stream
+            unpacker = None
+            if is_eth: 
+                unpacker = unpacker_eth_slftrg if is_selftrigger else unpacker_eth_stream
+            else:
+                unpacker = unpacker_slftrg if is_selftrigger else unpacker_stream
+
 
 
             #get and print fragment header
@@ -175,7 +183,7 @@ def main(filename, det, nrecords, nskip, channel_map, adc_stats, print_wvfm_samp
 
             if print_tp_info:
                 if not is_selftrigger:
-                    print(f'--print-tp-info called, but fragment is not kDAPHNE. Skipping...')
+                    print(f'--print-tp-info called, but fragment is not of self-trigger type. Skipping...')
                 else:
                     print(f'--PRINTING TP INFO--')
                     dict_tp_ch_ts = {}

--- a/scripts/daphne_decoder.py
+++ b/scripts/daphne_decoder.py
@@ -184,6 +184,8 @@ def main(filename, det, nrecords, nskip, channel_map, adc_stats, print_wvfm_samp
             if print_tp_info:
                 if not is_selftrigger:
                     print(f'--print-tp-info called, but fragment is not of self-trigger type. Skipping...')
+                elif is_eth:
+                    print(f'--print-tp-info not currently supported for DAPHNEEthFrame. Skipping...')
                 else:
                     print(f'--PRINTING TP INFO--')
                     dict_tp_ch_ts = {}


### PR DESCRIPTION
With `fddaq-v5.5.0` now cut, this source branch consists of a fork of the `develop` branch with `prep-release/fddaq-v5.5.0` merged in (i.e., this will be a fast-forward merge which brings the `fddaq-v5.5.0` code into `develop`). Over the weekend a test nightly was created, `MRGFD_DEV_251213_A9`, in which all the `johnfreeman/prep_release_merged` branches were used, and if I `pip install -U . ` the `johnfreeman/prep_release_merged` branch of `drunc`, integration tests with it look fine. 

# Description

_If full decription and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Addresses issue # 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

