### PR TITLE
rawdatautils 2.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-project(rawdatautils VERSION 2.6.0)
+project(rawdatautils VERSION 2.7.0)
 
 find_package(daq-cmake REQUIRED)
 find_package(fmt REQUIRED)


### PR DESCRIPTION
rawdatautils `2.7.0`

**Features**
- Add support for unpacking and decoding DAPHNE Ethernet streaming frames (`DAPHNEEthStreamFrame`)

**Improvements**
- Rename `error_bits` to `status_bits` in dataclasses and all related usage, aligning with upstream `daqdataformats` convention

**Maintenance**
- Sync GitHub issue forms and PR template with org-wide templates