### PR TITLE
Pybind fix

### DIFF
--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -21,12 +21,6 @@ extern void register_unpack(py::module &);
 }
 }
 
-namespace fc{
-namespace python {
-extern void register_file_conversion(py::module &);
-}
-}
-
 namespace python {
 
 PYBIND11_MODULE(_daq_rawdatautils_py, m) {
@@ -35,9 +29,6 @@ PYBIND11_MODULE(_daq_rawdatautils_py, m) {
 
     py::module_ unpack_module = m.def_submodule("unpack");
     unpack::python::register_unpack(unpack_module);
-
-    py::module_ fc_module = m.def_submodule("file_conversion");
-    fc::python::register_file_conversion(fc_module);
 
 }
 


### PR DESCRIPTION
# Description

There was a pybind registration left over from the removal of old frames in https://github.com/DUNE-DAQ/rawdatautils/pull/120/changes.

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [X] Unit tests pass (e.g. `dbt-build --unittest`)
- [X] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [X] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

